### PR TITLE
[FIX] #83, #84 장바구니 상품 등록 시 영속성 문제 해결, 장바구니 전체 조회 연동

### DIFF
--- a/src/main/java/com/thock/back/api/boundedContext/market/app/MarketCreateCartUseCase.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/app/MarketCreateCartUseCase.java
@@ -11,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class MarketCreateCartUseCase {
     private final MarketMemberRepository marketMemberRepository;
     private final CartRepository cartRepository;

--- a/src/main/java/com/thock/back/api/boundedContext/market/app/MarketFacade.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/app/MarketFacade.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class MarketFacade {
 
     private final MarketSyncMemberUseCase marketSyncMemberUseCase;
@@ -30,10 +29,12 @@ public class MarketFacade {
         return marketCreateCartUseCase.createCart(buyer);
     }
 
+    @Transactional(readOnly = true)
     public CartItemListResponse getCartItems(Long memberId){
         return cartService.getCartItems(memberId);
     }
 
+    @Transactional
     public CartItemResponse addCartItem(Long memberId, CartItemAddRequest request){
         return cartService.addCartItem(memberId, request);
     }

--- a/src/main/java/com/thock/back/api/boundedContext/market/domain/CartItem.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/domain/CartItem.java
@@ -1,11 +1,7 @@
 package com.thock.back.api.boundedContext.market.domain;
 
 import com.thock.back.api.global.jpa.entity.BaseIdAndTime;
-import com.thock.back.api.global.jpa.entity.BaseManualIdAndTime;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/thock/back/api/boundedContext/market/in/ApiV1CartController.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/in/ApiV1CartController.java
@@ -10,17 +10,18 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/carts")
+@Tag(name = "cart-controller")
 public class ApiV1CartController {
     private final MarketFacade marketFacade;
 

--- a/src/main/java/com/thock/back/api/boundedContext/market/in/dto/req/CartItemAddRequest.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/in/dto/req/CartItemAddRequest.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CartItemAddRequest {
-    @Schema(description = "상품 ID", example = "5")
+    @Schema(description = "상품 ID", example = "1")
     @NotNull(message = "상품 ID는 필수입니다.")
     private Long productId;
 

--- a/src/main/java/com/thock/back/api/boundedContext/market/out/api/ProductApiClient.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/out/api/ProductApiClient.java
@@ -5,8 +5,11 @@ import com.thock.back.api.boundedContext.market.out.client.ProductClient;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+
+import java.util.List;
 
 // Outbound Adapter (구현체)
 @Component
@@ -18,11 +21,13 @@ public class ProductApiClient implements ProductClient {
                 .baseUrl(internalBackUrl + "/api/v1/products")
                 .build();
     }
+
     @Override
-    public ProductInfo getProduct(Long productId) {
-        return restClient.get()
-                .uri("/{id}", productId)
+    public List<ProductInfo> getProducts(List<Long> productIds) {
+        return restClient.post()
+                .uri("/internal/list")
+                .body(productIds)
                 .retrieve()
-                .body(ProductInfo.class);
+                .body(new ParameterizedTypeReference<List<ProductInfo>>() {});
     }
 }

--- a/src/main/java/com/thock/back/api/boundedContext/market/out/api/dto/ProductInfo.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/out/api/dto/ProductInfo.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-// TODO : 필드 수정
 public class ProductInfo {
     private Long id;
     private String name;
@@ -13,13 +12,5 @@ public class ProductInfo {
     private Long price;
     private Long salePrice;
     private Integer stock;
-//    private boolean isAvailable; 품절인지 아닌지
-
-    /**
-     * 👇 ProductState를 그대로 받아오면 안됨.
-     * product 모듈을 import 하게 되기 때문.
-     */
-    // private ProductState state
-
-
+    private String state; // ProductState
 }

--- a/src/main/java/com/thock/back/api/boundedContext/market/out/client/ProductClient.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/out/client/ProductClient.java
@@ -2,7 +2,9 @@ package com.thock.back.api.boundedContext.market.out.client;
 
 import com.thock.back.api.boundedContext.market.out.api.dto.ProductInfo;
 
+import java.util.List;
+
 // Outbound Port (인터페이스)
 public interface ProductClient {
-    ProductInfo getProduct(Long productId);
+    List<ProductInfo> getProducts(List<Long> productIds);
 }

--- a/src/main/java/com/thock/back/api/global/security/SecurityConfig.java
+++ b/src/main/java/com/thock/back/api/global/security/SecurityConfig.java
@@ -38,7 +38,10 @@ public class SecurityConfig {
 
                                 // 인증/회원가입
                                 "/api/v1/auth/**",
-                                "/api/v1/members/signup"
+                                "/api/v1/members/signup",
+
+                                // 내부 API
+                                "/api/v1/products/internal/**"
                         ).permitAll()
                         .anyRequest().authenticated()   // ← 여기 중요 (JWT 없으면 접근 불가)
                 )

--- a/src/test/java/com/thock/back/api/marketTest/CartIntegrationTest.java
+++ b/src/test/java/com/thock/back/api/marketTest/CartIntegrationTest.java
@@ -12,6 +12,7 @@ import com.thock.back.api.boundedContext.market.out.repository.CartRepository;
 import com.thock.back.api.boundedContext.market.out.repository.MarketMemberRepository;
 import com.thock.back.api.boundedContext.product.domain.Category;
 import com.thock.back.api.boundedContext.product.domain.Product;
+import com.thock.back.api.boundedContext.product.domain.ProductState;
 import com.thock.back.api.boundedContext.product.out.ProductRepository;
 import com.thock.back.api.shared.member.domain.MemberRole;
 import com.thock.back.api.shared.member.domain.MemberState;
@@ -24,8 +25,11 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
@@ -89,9 +93,11 @@ public class CartIntegrationTest {
                 testProduct.getImageUrl(),
                 testProduct.getPrice(),
                 testProduct.getSalePrice(),
-                testProduct.getStock()
+                testProduct.getStock(),
+                testProduct.getState().name()
         );
-        given(productClient.getProduct(anyLong())).willReturn(mockProductInfo);
+        given(productClient.getProducts(anyList()))
+                .willReturn(List.of(mockProductInfo));
     }
 
     @Test
@@ -157,9 +163,11 @@ public class CartIntegrationTest {
                 cheapProduct.getImageUrl(),
                 cheapProduct.getPrice(),
                 cheapProduct.getSalePrice(),
-                cheapProduct.getStock()
+                cheapProduct.getStock(),
+                cheapProduct.getState().name()
         );
-        given(productClient.getProduct(cheapProduct.getId())).willReturn(mockCheapProductInfo);
+        given(productClient.getProducts(anyList()))
+                .willReturn(List.of(mockCheapProductInfo));
 
         // When: 저렴한 상품 1개 추가 (총 12,000원 - 배송비 발생)
         CartItemAddRequest request = new CartItemAddRequest(cheapProduct.getId(), 1);
@@ -214,9 +222,11 @@ public class CartIntegrationTest {
                 limitedProduct.getImageUrl(),
                 limitedProduct.getPrice(),
                 limitedProduct.getSalePrice(),
-                limitedProduct.getStock()
+                limitedProduct.getStock(),
+                limitedProduct.getState().name()
         );
-        given(productClient.getProduct(limitedProduct.getId())).willReturn(mockLimitedProductInfo);
+        given(productClient.getProducts(anyList()))
+                .willReturn(List.of(mockLimitedProductInfo));
 
         // When & Then: 재고보다 많은 수량 요청 시 예외 발생
         CartItemAddRequest request = new CartItemAddRequest(limitedProduct.getId(), 15);  // 15개 요청 (재고 10개)


### PR DESCRIPTION
## 🔗 관련 이슈
- #83 
- #84 

## 📝 작업 내용
이 PR에서 수행한 작업을 간단히 요약해주세요.(구현 방법, 설계 포인트)
장바구니에 상품 추가 시 장바구니ID, 상품ID, 수량에 데이터가 제대로 삽입되지 않고 null 값이 들어감
그로 인해 장바구니 조회도 동작을 하지 않음(해당 장바구니ID 들어있는 상품이 없다고 나옴)
marketSupport를 이용하지 않고 바로 CartRepository를 사용하니 해결됨. 
영속성 문제

### 🧪 테스트 (검증/실행 방법/결과)
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [ ] 로컬에서 테스트 완료
- [ ] Postman/Swagger 테스트 완료

### 📸 스크린샷 (선택사항)
API 테스트 결과나 UI 변경사항 등

## 📋 리뷰 요청 사항 (선택사항)
리뷰어가 특히 봐주었으면 하는 부분을 적어주세요.
- 
-

## 📚 참고 자료 (선택사항)
관련 문서나 레퍼런스가 있다면 링크를 추가해주세요.
- 
-


