### PR TITLE
[FEAT] # 148 - 정산 세부내역서 발행기능 추가

### DIFF
--- a/src/main/java/com/thock/back/api/boundedContext/settlement/app/DailySettlementUseCase.java
+++ b/src/main/java/com/thock/back/api/boundedContext/settlement/app/DailySettlementUseCase.java
@@ -63,8 +63,25 @@ public class DailySettlementUseCase {
                 .appliedFeeRate(5.0)
                 .build();
 
-        // 상세 내역 추가 로직 (생략 - 기존과 동일) ...
+        // 4. [상세 내역 추가]
+        for (SettlementOrderDto orderDto : orders) {
+            SettlementDetail detail = SettlementDetail.builder()
+                    .orderId(orderDto.getOrderId())         // 주문 번호
+                    .orderItemId(orderDto.getOrderItemId()) // 주문 상품 번호
+                    .productId(orderDto.getProductId())     // 상품 ID
+                    .productName(orderDto.getProductName()) // 상품명 (스냅샷)
+                    .quantity(orderDto.getQuantity())       // 수량
+                    .paymentAmount(orderDto.getTotalSalePrice()) // 결제 금액
+                    .payoutAmount(orderDto.getPayoutAmount())    // 정산 금액
+                    .fee(orderDto.getFeeAmount())                // 수수료
+                    .build();
 
+            // Settlement(부모)에 Detail(자식)을 연결
+            settlement.addDetail(detail);
+        }
+        // ==========================================
+
+        // 5. 저장 (이때 마스터와 디테일이 같이 저장됨 - Cascade 설정 덕분)
         settlementRepository.save(settlement);
 
         // 4. [핵심] 이벤트 발행! 📢


### PR DESCRIPTION
## 🔗 관련 이슈
#148 

## 📝 작업 내용
이 PR에서 수행한 작업을 간단히 요약해주세요.(구현 방법, 설계 포인트)

- 정산이 실행 될 떄, 자동적으로 정산 세부내역서도 저장되게 하였음.

- 정산 테이블에는 정산ID, 판매자 ID, 정산 날짜, 정산 금액 등 오로지 정산에 관련한 굵직한 내용만 들어가 있음.

- 정산 세부내역서 테이블에는 수수료, 주문 전체내역서ID, 주문 상세내역서ID, 결제금액, 정산될 금액, 상품ID, 상품 이름, 수량, 정산 ID가 포함됨

### 🧪 테스트 (검증/실행 방법/결과)
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [ ] 로컬에서 테스트 완료
- [ ] Postman/Swagger 테스트 완료

### 📸 스크린샷 (선택사항)
API 테스트 결과나 UI 변경사항 등

## 📋 리뷰 요청 사항 (선택사항)
리뷰어가 특히 봐주었으면 하는 부분을 적어주세요.
- 
-

## 📚 참고 자료 (선택사항)
관련 문서나 레퍼런스가 있다면 링크를 추가해주세요.
- 
-


