### PR TITLE
[FEAT]  #141 주문 취소 연동

### DIFF
--- a/src/main/java/com/thock/back/api/boundedContext/market/app/MarketCancelOrderPaymentUseCase.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/app/MarketCancelOrderPaymentUseCase.java
@@ -1,0 +1,57 @@
+package com.thock.back.api.boundedContext.market.app;
+
+import com.thock.back.api.boundedContext.market.domain.Order;
+import com.thock.back.api.boundedContext.market.domain.OrderItem;
+import com.thock.back.api.boundedContext.market.out.repository.OrderRepository;
+import com.thock.back.api.global.eventPublisher.EventPublisher;
+import com.thock.back.api.global.exception.CustomException;
+import com.thock.back.api.global.exception.ErrorCode;
+import com.thock.back.api.shared.market.event.MarketOrderPaymentRequestCanceledEvent;
+import com.thock.back.api.shared.payment.dto.PaymentCancelRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MarketCancelOrderPaymentUseCase {
+    private final OrderRepository orderRepository;
+    private final EventPublisher eventPublisher;
+
+    @Transactional
+    public void cancelOrder(Long memberId, Long orderId){
+        // 1. 주문 조회
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        // 2. 본인 주문인지 확인
+        if (!order.getBuyer().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.ORDER_USER_FORBIDDEN);
+        }
+
+        // 3. 도메인 메서드 호출 (이벤트 발행은 도메인이 처리)
+        if (order.isPaymentInProgress()) {
+            order.cancelRequestPayment();
+        } else {
+            order.cancel();
+        }
+    }
+
+    // 부분 취소
+    @Transactional
+    public void cancelOrderItem(Long memberId, Long orderId, Long orderItemId) {
+        // 1. 주문 조회
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        // 2. 본인 주문인지 확인
+        if (!order.getBuyer().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.USER_FORBIDDEN);
+        }
+
+        // 3. 도메인 메서드 호출 (이벤트 발행은 도메인이 처리)
+        order.cancelItem(orderItemId);
+    }
+}

--- a/src/main/java/com/thock/back/api/boundedContext/market/app/MarketCancelOrderRequestPaymentUseCase.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/app/MarketCancelOrderRequestPaymentUseCase.java
@@ -1,4 +1,0 @@
-package com.thock.back.api.boundedContext.market.app;
-
-public class MarketCancelOrderRequestPaymentUseCase {
-}

--- a/src/main/java/com/thock/back/api/boundedContext/market/app/MarketFacade.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/app/MarketFacade.java
@@ -20,6 +20,8 @@ public class MarketFacade {
     private final MarketSyncMemberUseCase marketSyncMemberUseCase;
     private final MarketCreateCartUseCase marketCreateCartUseCase;
     private final MarketCreateOrderUseCase marketCreateOrderUseCase;
+    private final MarketCompleteOrderPaymentUseCase marketCompleteOrderPaymentUseCase;
+    private final MarketCancelOrderPaymentUseCase marketCancelOrderPaymentUseCase;
     private final CartService cartService;
 
     @Transactional
@@ -45,5 +47,20 @@ public class MarketFacade {
     @Transactional
     public OrderCreateResponse createOrder(Long memberId, OrderCreateRequest request) {
         return marketCreateOrderUseCase.createOrder(memberId, request);
+    }
+
+    @Transactional
+    public void completeOrderPayment(Long orderId){
+        marketCompleteOrderPaymentUseCase.completeOrderPayment(orderId);
+    }
+
+    @Transactional
+    public void cancelOrder(Long memberId, Long orderId) {
+        marketCancelOrderPaymentUseCase.cancelOrder(memberId, orderId);
+    }
+
+    @Transactional
+    public void cancelOrderItem(Long memberId, Long orderId, Long orderItemId) {
+        marketCancelOrderPaymentUseCase.cancelOrderItem(memberId, orderId, orderItemId);
     }
 }

--- a/src/main/java/com/thock/back/api/boundedContext/market/in/ApiV1OrderController.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/in/ApiV1OrderController.java
@@ -37,9 +37,49 @@ public class ApiV1OrderController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류 (상품 정보 조회 실패 등)", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping
-    public ResponseEntity<OrderCreateResponse> addCartItem(@Valid @RequestBody OrderCreateRequest request) throws Exception {
+    public ResponseEntity<OrderCreateResponse> createOrder(@Valid @RequestBody OrderCreateRequest request) throws Exception {
         Long memberId = AuthContext.memberId();
         OrderCreateResponse response = marketFacade.createOrder(memberId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
+    @Operation(
+            summary = "주문 전체 취소",
+            description = "주문 전체를 취소합니다. " +
+                    "결제 완료된 주문의 경우 환불 처리가 진행됩니다. " +
+                    "주문은 삭제되지 않고 취소 상태로 변경됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주문 취소 성공"),
+            @ApiResponse(responseCode = "400", description = "취소 불가능한 주문 상태"),
+            @ApiResponse(responseCode = "403", description = "본인의 주문이 아님"),
+            @ApiResponse(responseCode = "404", description = "주문을 찾을 수 없음")
+    })
+    @PostMapping("/{orderId}")
+    public ResponseEntity<Void> calcelOrder(@PathVariable Long orderId) throws Exception {
+        Long memberId = AuthContext.memberId();
+        marketFacade.cancelOrder(memberId,orderId);
+        return ResponseEntity.ok().build();
+    }
+
+//    @Operation(
+//            summary = "주문 상품 부분 취소",
+//            description = "주문 내 특정 상품만 취소합니다. " +
+//                    "결제 완료된 경우 해당 상품 금액만큼 부분 환불됩니다."
+//    )
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "상품 취소 성공"),
+//            @ApiResponse(responseCode = "400", description = "취소 불가능한 상태"),
+//            @ApiResponse(responseCode = "403", description = "본인의 주문이 아님"),
+//            @ApiResponse(responseCode = "404", description = "주문 또는 상품을 찾을 수 없음")
+//    })
+//    @PostMapping("/{orderId}/items/{orderItemId}")
+//    public ResponseEntity<Void> cancelOrderItem(
+//            @PathVariable Long orderId,
+//            @PathVariable Long orderItemId
+//    ) throws Exception {
+//        Long memberId = AuthContext.memberId();
+//        marketFacade.cancelOrderItem(memberId, orderId, orderItemId);
+//        return ResponseEntity.ok().build();
+//    }
 }

--- a/src/main/java/com/thock/back/api/boundedContext/market/in/MarketEventListener.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/in/MarketEventListener.java
@@ -2,6 +2,7 @@ package com.thock.back.api.boundedContext.market.in;
 
 import com.thock.back.api.boundedContext.market.app.MarketFacade;
 import com.thock.back.api.shared.market.event.MarketMemberCreatedEvent;
+import com.thock.back.api.shared.market.event.MarketOrderPaymentCompletedEvent;
 import com.thock.back.api.shared.member.event.MemberJoinedEvent;
 import com.thock.back.api.shared.member.event.MemberModifiedEvent;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +36,12 @@ public class MarketEventListener {
         marketFacade.createCart(event.getMember());
     }
 
-
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @Transactional(propagation = REQUIRES_NEW)
+    public void handle(MarketOrderPaymentCompletedEvent event){
+        Long orderId = event.getOrder().getId();
+        marketFacade.completeOrderPayment(orderId);
+    }
 
 
 }

--- a/src/main/java/com/thock/back/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/thock/back/api/global/exception/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
     ORDER_INVALID_STATE("ORDER-400-2", "주문 상태가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     ORDER_CANNOT_CANCEL("ORDER-400-3", "주문 취소가 불가능한 상태입니다.", HttpStatus.BAD_REQUEST),
     ORDER_NO_ITEMS_SELECTED("ORDER-400-4", "주문할 상품을 선택해주세요.", HttpStatus.BAD_REQUEST),
+    ORDER_USER_FORBIDDEN("ORDER-403-1", "주문 취소할 권한이 없습니다.", HttpStatus.FORBIDDEN),
     ORDER_NOT_FOUND("ORDER-404-1", "주문을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     ORDER_ITEM_NOT_FOUND("ORDER-404-1", "주문 상품을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     // ===== 배송 =====


### PR DESCRIPTION
## 🔗 관련 이슈
- #141 


## 📝 작업 내용
이 PR에서 수행한 작업을 간단히 요약해주세요.(구현 방법, 설계 포인트)
- 주문 취소, 이벤트를 결제 모듈에 전달 
- 결제 완료 이벤트 받기

### 🧪 테스트 (검증/실행 방법/결과)
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [ ] 로컬에서 테스트 완료
- [ ] Postman/Swagger 테스트 완료

### 📸 스크린샷 (선택사항)
API 테스트 결과나 UI 변경사항 등

## 📋 리뷰 요청 사항 (선택사항)
리뷰어가 특히 봐주었으면 하는 부분을 적어주세요.
- 
-

## 📚 참고 자료 (선택사항)
관련 문서나 레퍼런스가 있다면 링크를 추가해주세요.
- 
-


