### PR TITLE
[CHORE] #995 - 주문서 가져오는 로직 수정, 정산 로직 수정

### DIFF
--- a/src/main/java/com/thock/back/api/boundedContext/market/out/adapter/MarketDataAdapter.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/out/adapter/MarketDataAdapter.java
@@ -22,7 +22,7 @@ public class MarketDataAdapter implements MarketDataPort {
         // 1. 구매 확정된 주문 아이템 조회
         List<OrderItem> items = orderItemRepository.findBySellerIdAndStatusAndDate(
                 sellerId,
-                OrderItemState.CONFIRMED,
+                OrderItemState.PAYMENT_COMPLETED,
                 date
         );
 

--- a/src/main/java/com/thock/back/api/boundedContext/settlement/app/SettlementMemberSyncUseCase.java
+++ b/src/main/java/com/thock/back/api/boundedContext/settlement/app/SettlementMemberSyncUseCase.java
@@ -4,18 +4,19 @@ import com.thock.back.api.boundedContext.settlement.domain.SettlementMember;
 import com.thock.back.api.boundedContext.settlement.out.SettlementMemberRepository;
 import com.thock.back.api.shared.member.dto.MemberDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service; // 👈 이거 꼭 붙여주세요!
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service // 빈 등록 필수
+@Slf4j
+@Service
 @RequiredArgsConstructor
 public class SettlementMemberSyncUseCase {
 
     private final SettlementMemberRepository settlementMemberRepository;
 
     @Transactional
-    public void syncMember(MemberDto memberDto) { // 메서드 이름 소문자 시작 권장 (camelCase)
-
+    public void syncMember(MemberDto memberDto) {
         settlementMemberRepository.findById(memberDto.getId())
                 .ifPresentOrElse(
                         // 1. 이미 존재하면 -> 업데이트 (Update)
@@ -30,12 +31,10 @@ public class SettlementMemberSyncUseCase {
                                     memberDto.getAccountHolder(),
                                     memberDto.getUpdatedAt() // 수정일 동기화
                             );
-                            // Transactional 덕분에 save 호출 안 해도 자동 update 쿼리 나감 (더티 체킹)
                         },
-                        // 2. 없으면 -> 새로 생성 (Insert)
                         () -> {
-                            SettlementMember newMember = SettlementMember.builder() // 빌더 패턴 추천
-                                    .id(memberDto.getId())
+                            SettlementMember newMember = SettlementMember.builder()
+                                    .id(memberDto.getId()) // ID 그대로 사용 (중요)
                                     .email(memberDto.getEmail())
                                     .name(memberDto.getName())
                                     .role(memberDto.getRole())

--- a/src/main/java/com/thock/back/api/boundedContext/settlement/in/SettlementTestController.java
+++ b/src/main/java/com/thock/back/api/boundedContext/settlement/in/SettlementTestController.java
@@ -1,20 +1,30 @@
 package com.thock.back.api.boundedContext.settlement.in;
 
 import com.thock.back.api.boundedContext.settlement.app.DailySettlementScheduler;
+import com.thock.back.api.boundedContext.settlement.app.SettlementFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
 public class SettlementTestController {
-
-    private final DailySettlementScheduler scheduler;
+    private final SettlementFacade settlementFacade;     // ⭕ 파사드를 직접 써야 날짜를 내 맘대로 넣음
 
     // 브라우저에서 http://localhost:8080/test/run 입력하면 실행됨
     @GetMapping("/test/run")
-    public String forceRun() {
-        scheduler.runDailySettlement(); // 스케줄러 강제 실행!
-        return "정산 배치 강제 실행 완료! H2 Console을 확인하세요.";
+    public String forceRun(@RequestParam(required = false) LocalDate date) {
+
+        // 날짜 파라미터가 없으면 '오늘' 날짜로 실행! (방금 주문한 거 테스트 가능)
+        if (date == null) {
+            date = LocalDate.now();
+        }
+
+        settlementFacade.runDailySettlement(date); // 👈 파사드에게 "오늘 날짜"를 줌
+
+        return date + " 일자 정산 배치 강제 실행 완료! H2 Console을 확인하세요.";
     }
 }

--- a/src/main/resources/static/checkout.html
+++ b/src/main/resources/static/checkout.html
@@ -71,7 +71,7 @@
         }
 
         // TODO: success/fail URL은 실제 서버 주소에 맞게 수정
-        const successUrl = "http://15.164.161.36//success.html";
+        const successUrl = "http://15.164.161.36/success.html";
         const failUrl = "http://15.164.161.36/fail.html";
 
         tossPayments.requestPayment("카드", {


### PR DESCRIPTION
## 🔗 관련 이슈


## 📝 작업 내용
이 PR에서 수행한 작업을 간단히 요약해주세요.(구현 방법, 설계 포인트)
- [ ] MarketDataAdapter가 가져오는 주문서의 상태를 CONFIRMED -> PAYMENT_COMPLETE로 변환
- [ ] 정산 강제 실행을 오늘 날짜로 가져오도록 변경


### 🧪 테스트 (검증/실행 방법/결과)
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [ ] 로컬에서 테스트 완료
- [ ] Postman/Swagger 테스트 완료

### 📸 스크린샷 (선택사항)
API 테스트 결과나 UI 변경사항 등

## 📋 리뷰 요청 사항 (선택사항)
리뷰어가 특히 봐주었으면 하는 부분을 적어주세요.
- 
-

## 📚 참고 자료 (선택사항)
관련 문서나 레퍼런스가 있다면 링크를 추가해주세요.
- 
-


