### PR TITLE
[FEAT] #172 - 새로 적용한 DNS 도메인 주소를 Spring Security origin에 추가

### DIFF
--- a/src/main/java/com/thock/back/api/global/security/SecurityConfig.java
+++ b/src/main/java/com/thock/back/api/global/security/SecurityConfig.java
@@ -85,7 +85,7 @@ public class SecurityConfig {
                 "http://localhost:5173",      // 로컬 개발
                 "https://thock.site",         // 운영 (www 없음)
                 "https://www.thock.site",      // 운영 (www 있음)
-                "https://api.thock.site"
+                "https://api.thock.site"        // 운영 API (DNS 주소)
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
## 🔗 관련 이슈
-#172 

## 📝 작업 내용
이 PR에서 수행한 작업을 간단히 요약해주세요.(구현 방법, 설계 포인트)
- [ ] 새로 적용한 DNS 도메인 주소를 Spring Security에서 알 수 있도록 설정 추가
