### PR TITLE
[FIX] #176 주문 생성 응답 시 pgAmount를 반환

### DIFF
--- a/src/main/java/com/thock/back/api/boundedContext/market/app/MarketCreateOrderUseCase.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/app/MarketCreateOrderUseCase.java
@@ -113,6 +113,7 @@ public class MarketCreateOrderUseCase {
         WalletInfo wallet = marketSupport.getWallet(buyer.getId());
         Long balance = wallet.getBalance();
 
+        Long pgAmount = Math.max(0L, savedOrder.getTotalSalePrice() - balance);
 
         // 9. 결제 요청 (Order 내부에서 pgAmount 계산 후 조건부 이벤트 발행)
         // - pgAmount <= 0: MarketOrderPaymentCompletedEvent 발행 (예치금만)
@@ -127,6 +128,6 @@ public class MarketCreateOrderUseCase {
                 savedOrder.getItems().size());
 
         // 11. 응답 생성 및 반환
-        return OrderCreateResponse.from(savedOrder);
+        return OrderCreateResponse.from(savedOrder, pgAmount);
     }
 }

--- a/src/main/java/com/thock/back/api/boundedContext/market/in/dto/res/OrderCreateResponse.java
+++ b/src/main/java/com/thock/back/api/boundedContext/market/in/dto/res/OrderCreateResponse.java
@@ -37,6 +37,9 @@ public class OrderCreateResponse {
     @Schema(description = "총 할인 금액", example = "60000")
     private Long totalDiscountAmount;
 
+    @Schema(description = "PG 결제 금액 (총 판매가 - 예치금)", example = "200000")
+    private Long pgAmount;
+
     @Schema(description = "배송지 - 우편번호", example = "06234")
     private String zipCode;
 
@@ -50,7 +53,7 @@ public class OrderCreateResponse {
     private LocalDateTime createdAt;
 
     // 정적 팩토리 메서드
-    public static OrderCreateResponse from(Order order) {
+    public static OrderCreateResponse from(Order order, Long pgAmount) {
         List<OrderItemInfo> itemInfos = order.getItems().stream()
                 .map(OrderItemInfo::from)
                 .collect(Collectors.toList());
@@ -63,6 +66,7 @@ public class OrderCreateResponse {
                 order.getTotalPrice(),
                 order.getTotalSalePrice(),
                 order.getTotalDiscountAmount(),
+                pgAmount,
                 order.getZipCode(),
                 order.getBaseAddress(),
                 order.getDetailAddress(),


### PR DESCRIPTION
## 🔗 관련 이슈
- #176 

## 📝 작업 내용
이 PR에서 수행한 작업을 간단히 요약해주세요.(구현 방법, 설계 포인트)

주문 생성 시 예치금을 조회하여 pgAmount를 계산함
이 값을 프론트로 보내주어야 프론트에서 정확한 결제가 가능해짐

현재는 결제가 테스트로 이루어지므로 예치금이 0원인 상태여서 문제가 생기지 않았지만
실 서비스에서는 에러가 발생하므로 pgAmount를 OrderCreateResponse에 추가함

### 🧪 테스트 (검증/실행 방법/결과)
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [ ] 로컬에서 테스트 완료
- [ ] Postman/Swagger 테스트 완료

### 📸 스크린샷 (선택사항)
API 테스트 결과나 UI 변경사항 등

## 📋 리뷰 요청 사항 (선택사항)
리뷰어가 특히 봐주었으면 하는 부분을 적어주세요.
- 
-

## 📚 참고 자료 (선택사항)
관련 문서나 레퍼런스가 있다면 링크를 추가해주세요.
- 
-


