### PR TITLE
[FEAT] #266 - 수동 컨트롤러 및 판매자페이지용 API 개발

### DIFF
--- a/settlement-service/src/main/java/com/thock/back/settlement/reconciliation/app/service/ManualReconciliationScenarioService.java
+++ b/settlement-service/src/main/java/com/thock/back/settlement/reconciliation/app/service/ManualReconciliationScenarioService.java
@@ -1,0 +1,128 @@
+package com.thock.back.settlement.reconciliation.app.service;
+
+import com.thock.back.settlement.reconciliation.app.ReconciliationFacade;
+import com.thock.back.settlement.reconciliation.domain.PgSalesRaw;
+import com.thock.back.settlement.reconciliation.domain.SalesLog;
+import com.thock.back.settlement.reconciliation.domain.enums.PgStatus;
+import com.thock.back.settlement.reconciliation.domain.enums.PaymentMethod;
+import com.thock.back.settlement.reconciliation.out.PgSalesRawRepository;
+import com.thock.back.settlement.reconciliation.out.SalesLogRepository;
+import com.thock.back.settlement.settlement.app.SettlementFacade;
+import com.thock.back.settlement.shared.enums.TransactionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ManualReconciliationScenarioService {
+
+    private final SalesLogRepository salesLogRepository;
+    private final PgSalesRawRepository pgSalesRawRepository;
+    private final ReconciliationFacade reconciliationFacade;
+    private final SettlementFacade settlementFacade;
+
+    @Transactional
+    public GeneratePgResult generatePgRawFromSalesLogs(LocalDate targetDate) {
+        LocalDateTime start = targetDate.atStartOfDay();
+        LocalDateTime end = targetDate.atTime(LocalTime.MAX);
+
+        List<SalesLog> logs = salesLogRepository.findAllBySnapshotAtBetween(start, end);
+        if (logs.isEmpty()) {
+            return new GeneratePgResult(targetDate, 0, 0, 0);
+        }
+
+        List<SalesLog> targetLogs = logs.stream()
+                .filter(log -> log.getTransactionType() == TransactionType.PAYMENT
+                        || log.getTransactionType() == TransactionType.REFUND)
+                .toList();
+
+        Map<String, List<SalesLog>> grouped = targetLogs.stream()
+                .collect(Collectors.groupingBy(log -> log.getOrderNo() + "|" + log.getTransactionType().name()));
+
+        // targetDate의 기존 PG RAW는 제거하고 다시 생성 (수동 재실행 시 중복 방지)
+        List<PgSalesRaw> existing = pgSalesRawRepository.findAllByTransactedAtBetween(start, end);
+        if (!existing.isEmpty()) {
+            pgSalesRawRepository.deleteAll(existing);
+        }
+
+        List<PgSalesRaw> generated = grouped.entrySet().stream()
+                .map(entry -> toPgRaw(entry.getValue(), targetDate))
+                .filter(Objects::nonNull)
+                .toList();
+
+        if (!generated.isEmpty()) {
+            pgSalesRawRepository.saveAll(generated);
+        }
+
+        return new GeneratePgResult(
+                targetDate,
+                logs.size(),
+                generated.size(),
+                generated.stream().mapToLong(PgSalesRaw::getPaymentAmount).sum()
+        );
+    }
+
+    public void runReconciliation(LocalDate targetDate) {
+        reconciliationFacade.runReconciliation(targetDate);
+    }
+
+    public void runDailySettlement(LocalDate targetDate) {
+        settlementFacade.runDaily(targetDate);
+    }
+
+    public void runMonthlySettlement(YearMonth targetMonth) {
+        settlementFacade.runMonthly(targetMonth);
+    }
+
+    @Transactional
+    public RunAllResult runAll(LocalDate targetDate) {
+        GeneratePgResult generate = generatePgRawFromSalesLogs(targetDate);
+        runReconciliation(targetDate);
+        runDailySettlement(targetDate);
+        runMonthlySettlement(YearMonth.from(targetDate));
+        return new RunAllResult(targetDate, YearMonth.from(targetDate), generate.generatedPgRows());
+    }
+
+    private PgSalesRaw toPgRaw(List<SalesLog> group, LocalDate targetDate) {
+        if (group.isEmpty()) {
+            return null;
+        }
+
+        SalesLog sample = group.get(0);
+        TransactionType txType = sample.getTransactionType();
+        PgStatus pgStatus = txType == TransactionType.REFUND ? PgStatus.CANCELED : PgStatus.PAID;
+        long amount = Math.abs(group.stream().mapToLong(SalesLog::getPaymentAmount).sum());
+
+        return PgSalesRaw.builder()
+                .pgKey("MANUAL-" + sample.getOrderNo() + "-" + pgStatus + "-" + System.currentTimeMillis())
+                .merchantUid(sample.getOrderNo())
+                .paymentMethod(sample.getPaymentMethod() == null ? PaymentMethod.CARD : sample.getPaymentMethod())
+                .paymentAmount(amount)
+                .pgStatus(pgStatus)
+                .transactedAt(LocalDateTime.of(targetDate, LocalTime.of(12, 0)))
+                .build();
+    }
+
+    public record GeneratePgResult(
+            LocalDate targetDate,
+            int sourceSalesLogs,
+            int generatedPgRows,
+            long totalGeneratedAmount
+    ) {}
+
+    public record RunAllResult(
+            LocalDate targetDate,
+            YearMonth targetMonth,
+            int generatedPgRows
+    ) {}
+}

--- a/settlement-service/src/main/java/com/thock/back/settlement/reconciliation/in/controller/ManualReconciliationController.java
+++ b/settlement-service/src/main/java/com/thock/back/settlement/reconciliation/in/controller/ManualReconciliationController.java
@@ -1,0 +1,75 @@
+package com.thock.back.settlement.reconciliation.in.controller;
+
+import com.thock.back.settlement.reconciliation.app.service.ManualReconciliationScenarioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Map;
+
+
+// 1차 통합테스트를 위한 수동 트키러
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/finance/reconciliation/manual")
+public class ManualReconciliationController {
+
+    private final ManualReconciliationScenarioService manualReconciliationScenarioService;
+
+    // SalesLog 기반 PG 데이터 생성 (대사 일치 과정 확인용)
+    @PostMapping("/generate-pg-from-saleslog")
+    public ManualReconciliationScenarioService.GeneratePgResult generatePgFromSalesLog(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate
+    ) {
+        LocalDate date = targetDate == null ? LocalDate.now() : targetDate;
+        return manualReconciliationScenarioService.generatePgRawFromSalesLogs(date);
+    }
+
+    // 일별 대사 수동 컨트롤러
+    @PostMapping("/run-reconciliation")
+    public Map<String, Object> runReconciliation(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate
+    ) {
+        LocalDate date = targetDate == null ? LocalDate.now() : targetDate;
+        manualReconciliationScenarioService.runReconciliation(date);
+        return Map.of("step", "reconciliation", "targetDate", date, "status", "done");
+    }
+
+    // 일별 정산 수동 컨트롤러
+    @PostMapping("/run-daily")
+    public Map<String, Object> runDaily(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate
+    ) {
+        LocalDate date = targetDate == null ? LocalDate.now() : targetDate;
+        manualReconciliationScenarioService.runDailySettlement(date);
+        return Map.of("step", "daily", "targetDate", date, "status", "done");
+    }
+
+    // 월별 정산 수동 컨트롤러
+    @PostMapping("/run-monthly")
+    public Map<String, Object> runMonthly(
+            @RequestParam(required = false) String targetMonth
+    ) {
+        YearMonth month = targetMonth == null ? YearMonth.now() : YearMonth.parse(targetMonth);
+        manualReconciliationScenarioService.runMonthlySettlement(month);
+        return Map.of("step", "monthly", "targetMonth", month.toString(), "status", "done");
+    }
+
+    // PG파일 생성 - 대사 -일별정산 - 월별정산 수동 총 진행
+    @PostMapping("/run-all")
+    public ManualReconciliationScenarioService.RunAllResult runAll(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate
+    ) {
+        LocalDate date = targetDate == null ? LocalDate.now() : targetDate;
+        return manualReconciliationScenarioService.runAll(date);
+    }
+}

--- a/settlement-service/src/main/java/com/thock/back/settlement/reconciliation/in/controller/OrderItemDataController.java
+++ b/settlement-service/src/main/java/com/thock/back/settlement/reconciliation/in/controller/OrderItemDataController.java
@@ -1,4 +1,21 @@
 package com.thock.back.settlement.reconciliation.in.controller;
 
+import com.thock.back.settlement.reconciliation.app.ReconciliationFacade;
+import com.thock.back.settlement.reconciliation.in.dto.OrderItemMessageDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
 public class OrderItemDataController {
+
+    private final ReconciliationFacade reconciliationFacade;
+
+    // 주문 이벤트 데이터 적재 (다른 모듈 이벤트 수신을 수동 호출로 대체)
+    @PostMapping("/api/v1/finance/reconciliation/order-item")
+    public void receiveOrderItem(@RequestBody OrderItemMessageDto dto) {
+        reconciliationFacade.receiveOrderItems(dto);
+    }
 }

--- a/settlement-service/src/main/java/com/thock/back/settlement/reconciliation/out/SalesLogRepository.java
+++ b/settlement-service/src/main/java/com/thock/back/settlement/reconciliation/out/SalesLogRepository.java
@@ -20,6 +20,7 @@ public interface SalesLogRepository extends JpaRepository<SalesLog, Long> {
             Long productId,
             TransactionType transactionType
     );
+    List<SalesLog> findAllBySnapshotAtBetween(LocalDateTime start, LocalDateTime end);
     List<SalesLog> findByOrderNoAndTransactionType(String orderNo, TransactionType transactionType);
     List<SalesLog> findAllBySnapshotAtBetweenAndReconciliationStatus(LocalDateTime start, LocalDateTime end, ReconciliationStatus status);
 

--- a/settlement-service/src/main/java/com/thock/back/settlement/settlement/app/SettlementFacade.java
+++ b/settlement-service/src/main/java/com/thock/back/settlement/settlement/app/SettlementFacade.java
@@ -1,4 +1,43 @@
 package com.thock.back.settlement.settlement.app;
 
+import com.thock.back.settlement.settlement.app.service.SettlementQueryService;
+import com.thock.back.settlement.settlement.app.useCase.RunDailySettlementUseCase;
+import com.thock.back.settlement.settlement.app.useCase.RunMonthlySettlementUseCase;
+import com.thock.back.settlement.settlement.in.dto.DailySettlementItemView;
+import com.thock.back.settlement.settlement.in.dto.MonthlySettlementView;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class SettlementFacade {
+
+    private final RunDailySettlementUseCase runDailySettlementUseCase;
+    private final RunMonthlySettlementUseCase runMonthlySettlementUseCase;
+    private final SettlementQueryService settlementQueryService;
+
+    @Transactional
+    public void runDaily(LocalDate targetDate) {
+        runDailySettlementUseCase.execute(targetDate);
+    }
+
+    @Transactional
+    public void runMonthly(YearMonth targetMonth) {
+        runMonthlySettlementUseCase.execute(targetMonth);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MonthlySettlementView> getMonthlySummary(Long sellerId, YearMonth targetMonth) {
+        return settlementQueryService.getMonthlySummary(sellerId, targetMonth);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DailySettlementItemView> getDailyItems(Long sellerId, LocalDate targetDate) {
+        return settlementQueryService.getDailyItems(sellerId, targetDate);
+    }
 }

--- a/settlement-service/src/main/java/com/thock/back/settlement/settlement/app/service/SettlementQueryService.java
+++ b/settlement-service/src/main/java/com/thock/back/settlement/settlement/app/service/SettlementQueryService.java
@@ -1,0 +1,72 @@
+package com.thock.back.settlement.settlement.app.service;
+
+import com.thock.back.settlement.settlement.domain.DailySettlement;
+import com.thock.back.settlement.settlement.domain.DailySettlementItem;
+import com.thock.back.settlement.settlement.domain.MonthlySettlement;
+import com.thock.back.settlement.settlement.in.dto.DailySettlementItemView;
+import com.thock.back.settlement.settlement.in.dto.MonthlySettlementView;
+import com.thock.back.settlement.settlement.out.DailySettlementRepository;
+import com.thock.back.settlement.settlement.out.MonthlySettlementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Comparator;
+import java.util.List;
+
+
+// 판매자가 확인하는 본인의 정산 내역 및 세부 정산서 관련 서비스
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SettlementQueryService {
+
+    private final DailySettlementRepository dailySettlementRepository;
+    private final MonthlySettlementRepository monthlySettlementRepository;
+
+    public List<MonthlySettlementView> getMonthlySummary(Long sellerId, YearMonth targetMonth) {
+        String targetYearMonth = targetMonth.toString().replace("-", "");
+        List<MonthlySettlement> rows = monthlySettlementRepository.findBySellerIdAndTargetYearMonth(sellerId, targetYearMonth);
+        return rows.stream()
+                .sorted(Comparator.comparing(MonthlySettlement::getCreatedAt, Comparator.nullsLast(Comparator.reverseOrder())))
+                .map(row -> new MonthlySettlementView(
+                        row.getId(),
+                        row.getSellerId(),
+                        row.getTargetYearMonth(),
+                        row.getTotalCount(),
+                        row.getTotalPaymentAmount(),
+                        row.getTotalFeeAmount(),
+                        row.getTotalPayoutAmount(),
+                        row.getStatus().name(),
+                        row.getCreatedAt(),
+                        row.getCompletedAt()
+                ))
+                .toList();
+    }
+
+    public List<DailySettlementItemView> getDailyItems(Long sellerId, LocalDate targetDate) {
+        List<DailySettlement> settlements = dailySettlementRepository.findBySellerIdAndTargetDate(sellerId, targetDate);
+        return settlements.stream()
+                .flatMap(settlement -> settlement.getItems().stream()
+                        .map(item -> toView(settlement, item)))
+                .sorted(Comparator.comparing(DailySettlementItemView::dailySettlementId))
+                .toList();
+    }
+
+    private DailySettlementItemView toView(DailySettlement settlement, DailySettlementItem item) {
+        return new DailySettlementItemView(
+                settlement.getId(),
+                settlement.getSellerId(),
+                settlement.getTargetDate(),
+                item.getId(),
+                item.getProductId(),
+                item.getProductName(),
+                item.getFinalQuantity(),
+                item.getFinalAmount(),
+                settlement.getStatus().name()
+        );
+    }
+}

--- a/settlement-service/src/main/java/com/thock/back/settlement/settlement/domain/DailySettlement.java
+++ b/settlement-service/src/main/java/com/thock/back/settlement/settlement/domain/DailySettlement.java
@@ -118,5 +118,14 @@ public class DailySettlement {
             // 저장하기 전에 TSID를 생성해서 넣음
             this.id = TsidCreator.getTsid().toLong();
         }
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void touchUpdatedAt() {
+        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/settlement-service/src/main/java/com/thock/back/settlement/settlement/in/controller/SettlementQueryController.java
+++ b/settlement-service/src/main/java/com/thock/back/settlement/settlement/in/controller/SettlementQueryController.java
@@ -1,0 +1,44 @@
+package com.thock.back.settlement.settlement.in.controller;
+
+import com.thock.back.settlement.settlement.app.service.SettlementQueryService;
+import com.thock.back.settlement.settlement.in.dto.DailySettlementItemView;
+import com.thock.back.settlement.settlement.in.dto.MonthlySettlementView;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+
+// 정산 관련 판매자 페이지에 들어갈 기능
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/finance/settlement/query")
+public class SettlementQueryController {
+
+    private final SettlementQueryService settlementQueryService;
+
+    // 월별 정산 내역
+    @GetMapping("/monthly")
+    public List<MonthlySettlementView> getMonthlySummary(
+            @RequestParam Long sellerId,
+            @RequestParam String targetMonth
+    ) {
+        return settlementQueryService.getMonthlySummary(sellerId, YearMonth.parse(targetMonth));
+    }
+
+    // 일별 정산 세부내역서
+    @GetMapping("/daily-items")
+    public List<DailySettlementItemView> getDailyItems(
+            @RequestParam Long sellerId,
+            @RequestParam
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate
+    ) {
+        return settlementQueryService.getDailyItems(sellerId, targetDate);
+    }
+}

--- a/settlement-service/src/main/java/com/thock/back/settlement/settlement/in/dto/DailySettlementItemView.java
+++ b/settlement-service/src/main/java/com/thock/back/settlement/settlement/in/dto/DailySettlementItemView.java
@@ -1,0 +1,16 @@
+package com.thock.back.settlement.settlement.in.dto;
+
+import java.time.LocalDate;
+
+public record DailySettlementItemView(
+        Long dailySettlementId,
+        Long sellerId,
+        LocalDate targetDate,
+        Long dailySettlementItemId,
+        Long productId,
+        String productName,
+        int finalQuantity,
+        Long finalAmount,
+        String dailySettlementStatus
+) {
+}

--- a/settlement-service/src/main/java/com/thock/back/settlement/settlement/in/dto/MonthlySettlementView.java
+++ b/settlement-service/src/main/java/com/thock/back/settlement/settlement/in/dto/MonthlySettlementView.java
@@ -1,0 +1,17 @@
+package com.thock.back.settlement.settlement.in.dto;
+
+import java.time.LocalDateTime;
+
+public record MonthlySettlementView(
+        Long monthlySettlementId,
+        Long sellerId,
+        String targetYearMonth,
+        Long totalCount,
+        Long totalPaymentAmount,
+        Long totalFeeAmount,
+        Long totalPayoutAmount,
+        String status,
+        LocalDateTime createdAt,
+        LocalDateTime completedAt
+) {
+}

--- a/settlement-service/src/main/java/com/thock/back/settlement/settlement/out/DailySettlementRepository.java
+++ b/settlement-service/src/main/java/com/thock/back/settlement/settlement/out/DailySettlementRepository.java
@@ -7,10 +7,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface DailySettlementRepository extends JpaRepository<DailySettlement, Long> {
-    List<DailySettlement> findBySellerIdAndTargetDateBetween(
-            Long sellerId, LocalDate startDate, LocalDate endDate
-    );
-    List<DailySettlement> findAllByTargetDateBetween(LocalDate startDate, LocalDate endDate);
 
+    //일별 판매 상세 목록
+    List<DailySettlement> findBySellerIdAndTargetDate(Long sellerId, LocalDate targetDate);
+
+    //일별 판매
+    List<DailySettlement> findAllByTargetDateBetween(LocalDate startDate, LocalDate endDate);
 
 }

--- a/settlement-service/src/main/java/com/thock/back/settlement/settlement/out/MonthlySettlementRepository.java
+++ b/settlement-service/src/main/java/com/thock/back/settlement/settlement/out/MonthlySettlementRepository.java
@@ -3,5 +3,8 @@ package com.thock.back.settlement.settlement.out;
 import com.thock.back.settlement.settlement.domain.MonthlySettlement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MonthlySettlementRepository extends JpaRepository <MonthlySettlement, Long> {
+    List<MonthlySettlement> findBySellerIdAndTargetYearMonth(Long sellerId, String targetYearMonth);
 }


### PR DESCRIPTION
## 🔗 관련 이슈
#266

## 📝 작업 내용
이 PR에서 수행한 작업을 간단히 요약해주세요.(구현 방법, 설계 포인트)
- 대사 - 일별정산 - 월별정산 통합테스트를 위한 API 개발
- 테스트 관련 기능 : 수동 주문서 추가, 수동 PG 데이터 추가, 수동 대사, 수동 일별 정산, 수동 월별 정산, 대사-일별정산-월별정산 일괄진행. 총 7개 기능 추가 
- 판매자 페이지 관련 기능 : 월 총 정산 결과, 일별 상세 정산 내역 API 추가. 총 2개 추가

### 🧪 테스트 (검증/실행 방법/결과)
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [ ] 로컬에서 테스트 완료
- [ ] Postman/Swagger 테스트 완료

### 📸 스크린샷 (선택사항)
API 테스트 결과나 UI 변경사항 등

## 📋 리뷰 요청 사항 (선택사항)
리뷰어가 특히 봐주었으면 하는 부분을 적어주세요.
- 
-

## 📚 참고 자료 (선택사항)
관련 문서나 레퍼런스가 있다면 링크를 추가해주세요.
- 
-


