### PR TITLE
[FIX] 배포 후 nginx reload 추가로 upstream IP 갱신 문제 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,4 +108,5 @@ jobs:
             cd ~/deploy
             docker compose -f docker-compose.yml pull
             docker compose -f docker-compose.yml up -d
+            docker exec nginx nginx -s reload
           EOF


### PR DESCRIPTION
## 🔗 관련 이슈
#이슈번호

## 📝 작업 내용
이 PR에서 수행한 작업을 간단히 요약해주세요.(구현 방법, 설계 포인트)
- [ ] docker compose up -d로 컨테이너 recreate 시 IP가 변경되면 nginx가 이전 IP를 캐싱하여 502 에러가 발생하는 문제 수정

### 🧪 테스트 (검증/실행 방법/결과)
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [ ] 로컬에서 테스트 완료
- [ ] Postman/Swagger 테스트 완료