### PR TITLE
[FEAT] #329 market 모듈 Inbox 패턴 도입

### DIFF
--- a/market-service/src/main/java/com/thock/back/market/MarketServiceApplication.java
+++ b/market-service/src/main/java/com/thock/back/market/MarketServiceApplication.java
@@ -14,11 +14,13 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 })
 @EnableJpaRepositories(basePackages = {
         "com.thock.back.market",
-        "com.thock.back.global.outbox.repository"
+        "com.thock.back.global.outbox.repository",
+        "com.thock.back.global.inbox.repository"
 })
 @EntityScan(basePackages = {
         "com.thock.back.market",
-        "com.thock.back.global.outbox.entity"
+        "com.thock.back.global.outbox.entity",
+        "com.thock.back.global.inbox.entity"
 })
 @EnableJpaAuditing
 @EnableScheduling

--- a/market-service/src/main/java/com/thock/back/market/in/MarketKafkaListener.java
+++ b/market-service/src/main/java/com/thock/back/market/in/MarketKafkaListener.java
@@ -1,14 +1,17 @@
 package com.thock.back.market.in;
 
 
+import com.thock.back.global.inbox.InboxGuard;
 import com.thock.back.global.kafka.KafkaTopics;
 import com.thock.back.market.app.MarketFacade;
+import com.thock.back.market.in.idempotency.MarketInboundEventIdempotencyKeyResolver;
 import com.thock.back.shared.member.event.MemberJoinedEvent;
 import com.thock.back.shared.member.event.MemberModifiedEvent;
 import com.thock.back.shared.payment.event.PaymentCompletedEvent;
 import com.thock.back.shared.payment.event.PaymentRefundCompletedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,11 +20,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 public class MarketKafkaListener {
+    private static final String MARKET_CONSUMER_GROUP = "market-service";
+
     private final MarketFacade marketFacade;
+    private final ObjectProvider<InboxGuard> inboxGuardProvider;
+    private final MarketInboundEventIdempotencyKeyResolver keyResolver;
 
     @KafkaListener(topics = KafkaTopics.MEMBER_JOINED, groupId = "market-service")
     @Transactional
     public void handle(MemberJoinedEvent event){
+        if (!shouldProcess(KafkaTopics.MEMBER_JOINED, keyResolver.memberJoined(event))) {
+            return;
+        }
         Long memberId = event.member().id();
         log.info("Received MemberJoinedEvent via Kafka: memberId={}", memberId);
         marketFacade.syncMember(event.member());
@@ -30,6 +40,9 @@ public class MarketKafkaListener {
     @KafkaListener(topics = KafkaTopics.MEMBER_MODIFIED, groupId = "market-service")
     @Transactional
     public void handle(MemberModifiedEvent event){
+        if (!shouldProcess(KafkaTopics.MEMBER_MODIFIED, keyResolver.memberModified(event))) {
+            return;
+        }
         Long memberId = event.member().id();
         log.info("Received MemberModifiedEvent via Kafka: memberId={}", memberId);
         marketFacade.syncMember(event.member());
@@ -39,6 +52,9 @@ public class MarketKafkaListener {
     @KafkaListener(topics = KafkaTopics.PAYMENT_COMPLETED, groupId = "market-service")
     @Transactional
     public void handle(PaymentCompletedEvent event){
+        if (!shouldProcess(KafkaTopics.PAYMENT_COMPLETED, keyResolver.paymentCompleted(event))) {
+            return;
+        }
         String orderNumber = event.payment().orderId();
         log.info("Received PaymentCompletedEvent via Kafka: orderNumber={}", orderNumber);
         marketFacade.completeOrderPayment(orderNumber);
@@ -47,11 +63,24 @@ public class MarketKafkaListener {
     @KafkaListener(topics = KafkaTopics.PAYMENT_REFUND_COMPLETED, groupId = "market-service")
     @Transactional
     public void handle(PaymentRefundCompletedEvent event){
+        if (!shouldProcess(
+                KafkaTopics.PAYMENT_REFUND_COMPLETED,
+                keyResolver.paymentRefundCompleted(event)
+        )) {
+            return;
+        }
         Long memberId = event.dto().memberId();
         String orderNumber = event.dto().orderId();
         log.info("Received PaymentRefundCompletedEvent via Kafka: memberId = {}, orderNumber={}", memberId, orderNumber);
         marketFacade.completeRefund(orderNumber);
     }
 
+    private boolean shouldProcess(String topic, String idempotencyKey) {
+        InboxGuard inboxGuard = inboxGuardProvider.getIfAvailable();
+        if (inboxGuard == null) {
+            return true;
+        }
+        return inboxGuard.tryClaim(idempotencyKey, topic, MARKET_CONSUMER_GROUP);
+    }
 
 }

--- a/market-service/src/main/java/com/thock/back/market/in/idempotency/MarketInboundEventIdempotencyKeyResolver.java
+++ b/market-service/src/main/java/com/thock/back/market/in/idempotency/MarketInboundEventIdempotencyKeyResolver.java
@@ -1,0 +1,42 @@
+package com.thock.back.market.in.idempotency;
+
+import com.thock.back.shared.member.event.MemberJoinedEvent;
+import com.thock.back.shared.member.event.MemberModifiedEvent;
+import com.thock.back.shared.payment.event.PaymentCompletedEvent;
+import com.thock.back.shared.payment.event.PaymentRefundCompletedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MarketInboundEventIdempotencyKeyResolver {
+
+    public String memberJoined(MemberJoinedEvent event) {
+        return String.join(":",
+                "member-joined",
+                String.valueOf(event.member().id())
+        );
+    }
+
+    public String memberModified(MemberModifiedEvent event) {
+        return String.join(":",
+                "member-modified",
+                String.valueOf(event.member().id()),
+                String.valueOf(event.member().updatedAt())
+        );
+    }
+
+    public String paymentCompleted(PaymentCompletedEvent event) {
+        return String.join(":",
+                "payment-completed",
+                event.payment().orderId(),
+                String.valueOf(event.payment().id())
+        );
+    }
+
+    public String paymentRefundCompleted(PaymentRefundCompletedEvent event) {
+        return String.join(":",
+                "payment-refund-completed",
+                event.dto().orderId(),
+                String.valueOf(event.dto().amount())
+        );
+    }
+}

--- a/market-service/src/main/resources/application.yml
+++ b/market-service/src/main/resources/application.yml
@@ -110,6 +110,9 @@ outbox:
   cleanup:
     cron: "0 0 3 * * *"
 
+inbox:
+  enabled: true
+
 logging:
   level:
     io.github.resilience4j.circuitbreaker: DEBUG

--- a/market-service/src/test/java/com/thock/back/market/in/MarketKafkaListenerTest.java
+++ b/market-service/src/test/java/com/thock/back/market/in/MarketKafkaListenerTest.java
@@ -1,0 +1,144 @@
+package com.thock.back.market.in;
+
+import com.thock.back.global.inbox.InboxGuard;
+import com.thock.back.global.kafka.KafkaTopics;
+import com.thock.back.market.app.MarketFacade;
+import com.thock.back.market.in.idempotency.MarketInboundEventIdempotencyKeyResolver;
+import com.thock.back.shared.member.domain.MemberRole;
+import com.thock.back.shared.member.domain.MemberState;
+import com.thock.back.shared.member.dto.MemberDto;
+import com.thock.back.shared.member.event.MemberJoinedEvent;
+import com.thock.back.shared.payment.dto.PaymentDto;
+import com.thock.back.shared.payment.event.PaymentCompletedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MarketKafkaListenerTest {
+
+    private static final String CONSUMER_GROUP = "market-service";
+
+    @Mock
+    private MarketFacade marketFacade;
+    @Mock
+    private ObjectProvider<InboxGuard> inboxGuardProvider;
+    @Mock
+    private InboxGuard inboxGuard;
+    @Mock
+    private MarketInboundEventIdempotencyKeyResolver keyResolver;
+
+    private MarketKafkaListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new MarketKafkaListener(marketFacade, inboxGuardProvider, keyResolver);
+    }
+
+    @Test
+    @DisplayName("MemberJoinedEvent 중복이면 syncMember를 호출하지 않는다")
+    void handleMemberJoined_duplicate_skips() {
+        MemberJoinedEvent event = new MemberJoinedEvent(memberDto(1L));
+
+        when(keyResolver.memberJoined(event)).thenReturn("member-joined:1");
+        when(inboxGuardProvider.getIfAvailable()).thenReturn(inboxGuard);
+        when(inboxGuard.tryClaim("member-joined:1", KafkaTopics.MEMBER_JOINED, CONSUMER_GROUP))
+                .thenReturn(false);
+
+        listener.handle(event);
+
+        verify(marketFacade, never()).syncMember(any());
+    }
+
+    @Test
+    @DisplayName("MemberJoinedEvent 최초 수신이면 syncMember를 호출한다")
+    void handleMemberJoined_claimed_processes() {
+        MemberJoinedEvent event = new MemberJoinedEvent(memberDto(2L));
+
+        when(keyResolver.memberJoined(event)).thenReturn("member-joined:2");
+        when(inboxGuardProvider.getIfAvailable()).thenReturn(inboxGuard);
+        when(inboxGuard.tryClaim("member-joined:2", KafkaTopics.MEMBER_JOINED, CONSUMER_GROUP))
+                .thenReturn(true);
+
+        listener.handle(event);
+
+        verify(marketFacade).syncMember(eq(event.member()));
+    }
+
+    @Test
+    @DisplayName("PaymentCompletedEvent 중복이면 completeOrderPayment를 호출하지 않는다")
+    void handlePaymentCompleted_duplicate_skips() {
+        PaymentCompletedEvent event = new PaymentCompletedEvent(paymentDto(10L, "ORDER-TEST-1"));
+
+        when(keyResolver.paymentCompleted(event)).thenReturn("payment-completed:ORDER-TEST-1:10");
+        when(inboxGuardProvider.getIfAvailable()).thenReturn(inboxGuard);
+        when(inboxGuard.tryClaim(
+                "payment-completed:ORDER-TEST-1:10",
+                KafkaTopics.PAYMENT_COMPLETED,
+                CONSUMER_GROUP
+        )).thenReturn(false);
+
+        listener.handle(event);
+
+        verify(marketFacade, never()).completeOrderPayment(any());
+    }
+
+    @Test
+    @DisplayName("PaymentCompletedEvent 최초 수신이면 completeOrderPayment를 호출한다")
+    void handlePaymentCompleted_claimed_processes() {
+        PaymentCompletedEvent event = new PaymentCompletedEvent(paymentDto(11L, "ORDER-TEST-2"));
+
+        when(keyResolver.paymentCompleted(event)).thenReturn("payment-completed:ORDER-TEST-2:11");
+        when(inboxGuardProvider.getIfAvailable()).thenReturn(inboxGuard);
+        when(inboxGuard.tryClaim(
+                "payment-completed:ORDER-TEST-2:11",
+                KafkaTopics.PAYMENT_COMPLETED,
+                CONSUMER_GROUP
+        )).thenReturn(true);
+
+        listener.handle(event);
+
+        verify(marketFacade).completeOrderPayment("ORDER-TEST-2");
+    }
+
+    private MemberDto memberDto(Long memberId) {
+        LocalDateTime now = LocalDateTime.now();
+        return new MemberDto(
+                memberId,
+                now,
+                now,
+                "user" + memberId + "@example.com",
+                "user" + memberId,
+                MemberRole.USER,
+                MemberState.ACTIVE,
+                null,
+                null,
+                null
+        );
+    }
+
+    private PaymentDto paymentDto(Long paymentId, String orderId) {
+        return new PaymentDto(
+                paymentId,
+                orderId,
+                "pk-test-" + paymentId,
+                1L,
+                1000L,
+                1000L,
+                LocalDateTime.now(),
+                0L
+        );
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #329 

## 📝 작업 내용
현재 이벤트를 최소 1번 보내는 방식
Consumer 중복 실행 방지
- Consumer 로직 실행 뒤 offset 커밋 실패

### 🧪 테스트 (검증/실행 방법/결과)
- [x] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [x] 로컬에서 테스트 완료
- [ ] Postman/Swagger 테스트 완료

### 📸 스크린샷 (선택사항)
<img width="574" height="249" alt="image" src="https://github.com/user-attachments/assets/fad6ea4f-a6fc-42d7-9783-1f98ac5bb269" />


## 📋 리뷰 요청 사항 (선택사항)
리뷰어가 특히 봐주었으면 하는 부분을 적어주세요.
- 
-

## 📚 참고 자료 (선택사항)
관련 문서나 레퍼런스가 있다면 링크를 추가해주세요.
- 
-


