### PR TITLE
[REFACTOR] # 장바구니 같은 상품 담는 경우 재고 수량 업데이트

### DIFF
--- a/market-service/src/main/java/com/thock/back/market/app/CartService.java
+++ b/market-service/src/main/java/com/thock/back/market/app/CartService.java
@@ -110,8 +110,13 @@ public class CartService {
             throw new CustomException(ErrorCode.CART_PRODUCT_API_FAILED);
         }
 
-        // 재고 확인
-        if (product.getStock() < request.quantity()) {
+        int existingQuantity = cart.getItems().stream()
+                .filter(item -> item.getProductId().equals(request.productId()))
+                .mapToInt(CartItem::getQuantity)
+                .sum();
+
+        // 재고 확인 (기존 장바구니 수량 + 신규 추가 수량)
+        if (product.getStock() < existingQuantity + request.quantity()) {
              throw new CustomException(ErrorCode.CART_PRODUCT_OUT_OF_STOCK);
         }
 

--- a/market-service/src/main/java/com/thock/back/market/domain/Cart.java
+++ b/market-service/src/main/java/com/thock/back/market/domain/Cart.java
@@ -42,6 +42,16 @@ public class Cart extends BaseManualIdAndTime {
     // 장바구니에 상품 등록
     // TODO : 상품 상태도 받아야 할듯, 그래야 판매중, 판매중지, 품절 표현 가능
     public CartItem addItem(Long productId, Integer quantity) {
+        CartItem existingItem = items.stream()
+                .filter(item -> item.getProductId().equals(productId))
+                .findFirst()
+                .orElse(null);
+
+        if (existingItem != null) {
+            existingItem.addQuantity(quantity);
+            return existingItem;
+        }
+
         CartItem cartItem = new CartItem(this, productId, quantity);
         this.items.add(cartItem);
         this.itemsCount++;
@@ -73,4 +83,3 @@ public class Cart extends BaseManualIdAndTime {
                 .orElseThrow(() -> new CustomException(ErrorCode.CART_ITEM_NOT_FOUND));
     }
 }
-

--- a/market-service/src/main/java/com/thock/back/market/domain/CartItem.java
+++ b/market-service/src/main/java/com/thock/back/market/domain/CartItem.java
@@ -33,4 +33,8 @@ public class CartItem extends BaseIdAndTime {
     public void updateQuantity(Integer quantity){
         this.quantity = quantity;
     }
+
+    public void addQuantity(Integer quantity) {
+        this.quantity += quantity;
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #336 

## 📝 작업 내용
- 기존: 같은 상품을 담더라도 cartItem의 Id가 다르도록 설정되어 있었음
- ProductApiClient 호출 시 나오는 productId 를 조회해서 기존에 장바구니에 해당 상품이 담겨 있으면 재고 수량만 update해주는 식으로 변경

### 🧪 테스트 (검증/실행 방법/결과)
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [ ] 로컬에서 테스트 완료
- [ ] Postman/Swagger 테스트 완료

### 📸 스크린샷 (선택사항)
API 테스트 결과나 UI 변경사항 등

## 📋 리뷰 요청 사항 (선택사항)
리뷰어가 특히 봐주었으면 하는 부분을 적어주세요.
- 
-

## 📚 참고 자료 (선택사항)
관련 문서나 레퍼런스가 있다면 링크를 추가해주세요.
- 
-


