### PR TITLE
[TASK] 관리자 대시보드 공개 접속 이슈 해결

### DIFF
--- a/AWS EC2/deploy-docker-compose/nginx/nginx.conf
+++ b/AWS EC2/deploy-docker-compose/nginx/nginx.conf
@@ -27,7 +27,15 @@ http {
         ssl_certificate /etc/letsencrypt/live/api.thock.site/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/api.thock.site/privkey.pem;
 
-        location /grafana/ {
+        location = /grafana {
+            allow 220.79.119.124;
+            deny all;
+            return 301 /grafana/;
+        }
+
+        location ^~ /grafana/ {
+            allow 220.79.119.124;
+            deny all;
             proxy_pass http://grafana:3000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -35,10 +43,20 @@ http {
 	    proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-      	location /redpanda/ {
+        location = /redpanda {
+            allow 220.79.119.124;
+            deny all;
+            return 301 /redpanda/;
+        }
+
+      	location ^~ /redpanda/ {
+            allow 220.79.119.124;
+            deny all;
        	    proxy_pass http://redpanda-console:8090;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
       	}
 
         location / {

--- a/AWS EC2/deploy-kubernetes/ingress/grafana-ingress.yaml
+++ b/AWS EC2/deploy-kubernetes/ingress/grafana-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: thock-grafana-ingress
+  namespace: thock-prod
+  annotations:
+    kubernetes.io/ingress.class: "traefik"
+    traefik.ingress.kubernetes.io/router.middlewares: "thock-prod-swagger-admin-ip-whitelist@kubernetescrd"
+spec:
+  tls:
+    - hosts:
+        - api.thock.site
+      secretName: thock-tls
+  rules:
+    - host: api.thock.site
+      http:
+        paths:
+          - path: /grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000
+

--- a/AWS EC2/deploy-kubernetes/ingress/ingress.yaml
+++ b/AWS EC2/deploy-kubernetes/ingress/ingress.yaml
@@ -25,21 +25,3 @@ spec:
             name: api-gateway
             port:
               number: 8080
-
-      # Grafana
-      - path: /grafana
-        pathType: Prefix
-        backend:
-          service:
-            name: grafana
-            port:
-              number: 3000
-
-      # Redpanda Console
-      - path: /redpanda
-        pathType: Prefix
-        backend:
-          service:
-            name: redpanda-console
-            port:
-              number: 8090

--- a/AWS EC2/deploy-kubernetes/ingress/redpanda-ingress.yaml
+++ b/AWS EC2/deploy-kubernetes/ingress/redpanda-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: thock-redpanda-ingress
+  namespace: thock-prod
+  annotations:
+    kubernetes.io/ingress.class: "traefik"
+    traefik.ingress.kubernetes.io/router.middlewares: "thock-prod-swagger-admin-ip-whitelist@kubernetescrd"
+spec:
+  tls:
+    - hosts:
+        - api.thock.site
+      secretName: thock-tls
+  rules:
+    - host: api.thock.site
+      http:
+        paths:
+          - path: /redpanda
+            pathType: Prefix
+            backend:
+              service:
+                name: redpanda-console
+                port:
+                  number: 8090
+


### PR DESCRIPTION
## 🔗 관련 이슈
#371 

## 📝 작업 내용
이 PR에서 수행한 작업을 간단히 요약해주세요.(구현 방법, 설계 포인트)
- [x] compose, kubernetes 환경 설정: 관리자 IP만 grafana, redpanda 접속 가능하도록 변경 

### 🧪 테스트 (검증/실행 방법/결과)
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [ ] 로컬에서 테스트 완료
- [x] Postman/Swagger 테스트 완료