### PR TITLE
[FEAT] #403 주문 중복 생성 방지

### DIFF
--- a/market-service/src/main/java/com/thock/back/market/app/MarketCancelOrderPaymentUseCase.java
+++ b/market-service/src/main/java/com/thock/back/market/app/MarketCancelOrderPaymentUseCase.java
@@ -25,14 +25,7 @@ public class MarketCancelOrderPaymentUseCase {
 
     @Transactional
     public void cancelOrder(Long memberId, Long orderId, CancelReasonType cancelReasonType, String cancelReasonDetail){
-        // 1. 주문 조회
-        Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-
-        // 2. 본인 주문인지 확인
-        if (!order.getBuyer().getId().equals(memberId)) {
-            throw new CustomException(ErrorCode.ORDER_USER_FORBIDDEN);
-        }
+        Order order = getOwnedOrder(memberId, orderId);
 
         // 3. 도메인 메서드 호출 (이벤트 발행은 도메인이 처리)
         if (order.isPaymentInProgress()) {
@@ -42,9 +35,12 @@ public class MarketCancelOrderPaymentUseCase {
         }
 
         // 4. 취소 히스토리 저장 (각 아이템별로)
-        List<OrderCancelHistory> histories = order.getItems().stream()
-                .map(item -> OrderCancelHistory.ofUserCancel(order, item, cancelReasonType, cancelReasonDetail))
-                .toList();
+        List<OrderCancelHistory> histories = buildUserCancelHistories(
+                order,
+                order.getItems(),
+                cancelReasonType,
+                cancelReasonDetail
+        );
         orderCancelHistoryRepository.saveAll(histories);
     }
 
@@ -57,14 +53,7 @@ public class MarketCancelOrderPaymentUseCase {
             CancelReasonType cancelReasonType,
             String cancelReasonDetail)
     {
-        // 1. 주문 조회
-        Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-
-        // 2. 본인 주문인지 확인
-        if (!order.getBuyer().getId().equals(memberId)) {
-            throw new CustomException(ErrorCode.USER_FORBIDDEN);
-        }
+        Order order = getOwnedOrder(memberId, orderId);
 
         // 3. 취소할 아이템 조회 (히스토리 저장용) - 취소 대상 아이템들 미리 확보
         List<OrderItem> itemsToCancel = order.getItems().stream()
@@ -75,9 +64,33 @@ public class MarketCancelOrderPaymentUseCase {
         order.cancelItems(orderItemIds, cancelReasonType, cancelReasonDetail);
 
         // 5. 취소 히스토리 저장 (취소된 아이템들만)
-        List<OrderCancelHistory> histories = itemsToCancel.stream()
+        List<OrderCancelHistory> histories = buildUserCancelHistories(
+                order,
+                itemsToCancel,
+                cancelReasonType,
+                cancelReasonDetail
+        );
+        orderCancelHistoryRepository.saveAll(histories);
+    }
+
+    private Order getOwnedOrder(Long memberId, Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.getBuyer().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.ORDER_USER_FORBIDDEN);
+        }
+        return order;
+    }
+
+    private List<OrderCancelHistory> buildUserCancelHistories(
+            Order order,
+            List<OrderItem> items,
+            CancelReasonType cancelReasonType,
+            String cancelReasonDetail
+    ) {
+        return items.stream()
                 .map(item -> OrderCancelHistory.ofUserCancel(order, item, cancelReasonType, cancelReasonDetail))
                 .toList();
-        orderCancelHistoryRepository.saveAll(histories);
     }
 }

--- a/market-service/src/main/java/com/thock/back/market/app/MarketCreateOrderUseCase.java
+++ b/market-service/src/main/java/com/thock/back/market/app/MarketCreateOrderUseCase.java
@@ -16,6 +16,7 @@ import com.thock.back.market.out.repository.MarketMemberRepository;
 import com.thock.back.market.out.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,102 +37,58 @@ public class MarketCreateOrderUseCase {
     // 주문 생성 - 장바구니 내 선택한 상품들만 주문에 들어감
     @Transactional
     public OrderCreateResponse createOrder(Long memberId, OrderCreateRequest request) {
-        /**
-         *  1. 회원 조회
-         *  같은 회원의 주문 생성 동시 요청을 직렬화해 TOCTOU(확인 시점, 사용 시점 사이 상태가 바뀌는 문제)를 방지한다.
-         *  동시 주문 요청이 들어와도 먼저 들어온 트랜잭션이 끝날 때까지 뒤 요청은 대기
-         *  대기 후 existsByBuyerIdAndState 에서 걸리므로 중복 생성 차단
-         */
-        MarketMember buyer = marketMemberRepository.findByIdForUpdate(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.CART_USER_NOT_FOUND));
+        return createOrder(memberId, request, null);
+    }
 
-        // 2. 미결제 주문 존재 여부 확인 (1인 1주문 제한)
-        if (orderRepository.existsByBuyerIdAndState(memberId, OrderState.PENDING_PAYMENT)) {
-            throw new CustomException(ErrorCode.ORDER_PENDING_EXISTS);
+    @Transactional
+    public OrderCreateResponse createOrder(Long memberId, OrderCreateRequest request, String idempotencyKey) {
+        String normalizedIdempotencyKey = normalizeIdempotencyKey(idempotencyKey);
+        MarketMember buyer = getBuyerForUpdate(memberId);
+
+        OrderCreateResponse idempotentResponse = findExistingOrderByIdempotencyKey(memberId, normalizedIdempotencyKey);
+        if (idempotentResponse != null) {
+            return idempotentResponse;
         }
 
-        // 3. 장바구니 조회
-        Cart cart = cartRepository.findByBuyer(buyer)
-                .orElseThrow(() -> new CustomException(ErrorCode.CART_ITEM_NOT_FOUND));
+        validateNoPendingOrder(memberId);
 
-        // 4. 선택한 CartItem들만 필터링
-        List<Long> selectedCartItemIds = request.cartItemIds();
+        Cart cart = getCartByBuyer(buyer);
+        List<CartItem> selectedCartItems = getSelectedCartItems(cart, request.cartItemIds());
+        Map<Long, ProductInfo> productMap = getProductMap(selectedCartItems);
 
-        if (selectedCartItemIds == null || selectedCartItemIds.isEmpty()) {
-            throw new CustomException(ErrorCode.ORDER_NO_ITEMS_SELECTED);
-        }
+        Order order = createOrderAggregate(buyer, request, normalizedIdempotencyKey);
+        appendOrderItems(order, selectedCartItems, productMap);
 
-        // 선택된 CartItem만 추출
-        List<CartItem> selectedCartItems = cart.getItems().stream()
-                .filter(item -> selectedCartItemIds.contains(item.getId()))
-                .toList();
+        Order savedOrder;
 
-        // 선택된 상품이 실제로 장바구니에 있는지 확인
-        if (selectedCartItems.isEmpty()) {
-            throw new CustomException(ErrorCode.CART_EMPTY);
-        }
-
-        // 4. 장바구니에 들어있는 상품 정보 조회 - 스냅샷 저장용
-        List<Long> productsId = selectedCartItems.stream()
-                .map(CartItem::getProductId)
-                .toList();
-        List<ProductInfo> products = marketSupport.getProducts(productsId);
-
-        // ProductInfo를 Map으로 변환 (빠른 조회)
-        Map<Long, ProductInfo> productMap = products.stream()
-                .collect(Collectors.toMap(ProductInfo::getId, Function.identity()));
-
-        // 5. Order 생성
-        Order order = new Order(
-                buyer,
-                request.zipCode(),
-                request.baseAddress(),
-                request.detailAddress()
-        );
-
-        // 6. OrderItem 추가 (상품 정보 스냅샷, 변경되면 안됨)
-        for (CartItem cartItem : selectedCartItems) {
-            ProductInfo product = productMap.get(cartItem.getProductId());
-
-            // 상품 정보가 없는 경우 (삭제된 상품 등)
-            if (product == null) {
-                log.warn("상품 정보를 찾을 수 없음: productId={}", cartItem.getProductId());
-                throw new CustomException(ErrorCode.CART_PRODUCT_INFO_NOT_FOUND);
+        try {
+            savedOrder = orderRepository.saveAndFlush(order);
+        } catch (DataIntegrityViolationException e) {
+            if (normalizedIdempotencyKey == null) {
+                throw e;
             }
 
-            // 재고 확인
-            if (product.getStock() < cartItem.getQuantity()) {
-                throw new CustomException(
-                        ErrorCode.CART_PRODUCT_OUT_OF_STOCK,
-                        String.format("%s 상품의 재고가 부족합니다. (필요: %d개, 재고: %d개)",
-                                product.getName(), cartItem.getQuantity(), product.getStock())
-                );
-            }
+            log.info("멱등 키 유니크 충돌 감지: memberId={}, idempotencyKey={}",
+                    memberId, normalizedIdempotencyKey);
 
-            // 주문 아이템 추가 (스냅샷 저장)
-            order.addItem(
-                    product.getSellerId(),
-                    product.getId(),
-                    product.getName(),
-                    product.getImageUrl(),
-                    product.getPrice(),
-                    product.getSalePrice(),
-                    cartItem.getQuantity()
-            );
+            return orderRepository.findByBuyerIdAndIdempotencyKey(memberId,
+                            normalizedIdempotencyKey)
+                    .map(existingOrder -> {
+                        WalletInfo wallet = marketSupport.getWallet(buyer.getId());
+                        Long balance = wallet.getBalance();
+                        Long pgAmount = Math.max(0L, existingOrder.getTotalSalePrice() -
+                                balance);
+                        return OrderCreateResponse.from(existingOrder, pgAmount);
+                    })
+                    .orElseThrow(() -> e);
         }
-        // 7. 주문 저장 (OrderItem도 Casecade로 함께 저장됨)
-        Order savedOrder = orderRepository.save(order);
 
 
-        // 8. 예치금 조회 및 pgAmount 계산
+
         WalletInfo wallet = marketSupport.getWallet(buyer.getId());
         Long balance = wallet.getBalance();
-
         Long pgAmount = Math.max(0L, savedOrder.getTotalSalePrice() - balance);
 
-        // 9. 결제 요청 (Order 내부에서 pgAmount 계산 후 조건부 이벤트 발행)
-        // - pgAmount <= 0: MarketOrderPaymentCompletedEvent 발행 (예치금만)
-        // - pgAmount > 0: MarketOrderPaymentRequestedEvent 발행 (PG 필요)
         savedOrder.requestPayment(balance);
 
         log.info("✅ 주문 생성 완료: orderId={}, orderNumber={}, buyerId={}, totalAmount={}, itemCount={}",
@@ -143,5 +100,110 @@ public class MarketCreateOrderUseCase {
 
         // 11. 응답 생성 및 반환
         return OrderCreateResponse.from(savedOrder, pgAmount);
+    }
+
+    private String normalizeIdempotencyKey(String idempotencyKey) {
+        if (idempotencyKey == null) {
+            return null;
+        }
+        String trimmed = idempotencyKey.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private MarketMember getBuyerForUpdate(Long memberId) {
+        return marketMemberRepository.findByIdForUpdate(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_USER_NOT_FOUND));
+    }
+
+    private OrderCreateResponse findExistingOrderByIdempotencyKey(Long memberId, String normalizedIdempotencyKey) {
+        if (normalizedIdempotencyKey == null) {
+            return null;
+        }
+
+        return orderRepository.findByBuyerIdAndIdempotencyKey(memberId, normalizedIdempotencyKey)
+                .map(order -> {
+                    log.info("멱등 키 재요청 감지: memberId={}, orderId={}, orderNumber={}",
+                            memberId, order.getId(), order.getOrderNumber());
+                    WalletInfo wallet = marketSupport.getWallet(memberId);
+                    Long balance = wallet.getBalance();
+                    Long pgAmount = Math.max(0L, order.getTotalSalePrice() - balance);
+                    return OrderCreateResponse.from(order, pgAmount);
+                })
+                .orElse(null);
+    }
+
+    private void validateNoPendingOrder(Long memberId) {
+        if (orderRepository.existsByBuyerIdAndState(memberId, OrderState.PENDING_PAYMENT)) {
+            throw new CustomException(ErrorCode.ORDER_PENDING_EXISTS);
+        }
+    }
+
+    private Cart getCartByBuyer(MarketMember buyer) {
+        return cartRepository.findByBuyer(buyer)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_ITEM_NOT_FOUND));
+    }
+
+    private List<CartItem> getSelectedCartItems(Cart cart, List<Long> selectedCartItemIds) {
+        if (selectedCartItemIds == null || selectedCartItemIds.isEmpty()) {
+            throw new CustomException(ErrorCode.ORDER_NO_ITEMS_SELECTED);
+        }
+
+        List<CartItem> selectedCartItems = cart.getItems().stream()
+                .filter(item -> selectedCartItemIds.contains(item.getId()))
+                .toList();
+
+        if (selectedCartItems.isEmpty()) {
+            throw new CustomException(ErrorCode.CART_EMPTY);
+        }
+        return selectedCartItems;
+    }
+
+    private Map<Long, ProductInfo> getProductMap(List<CartItem> selectedCartItems) {
+        List<Long> productsId = selectedCartItems.stream()
+                .map(CartItem::getProductId)
+                .toList();
+
+        return marketSupport.getProducts(productsId).stream()
+                .collect(Collectors.toMap(ProductInfo::getId, Function.identity()));
+    }
+
+    private Order createOrderAggregate(MarketMember buyer, OrderCreateRequest request, String normalizedIdempotencyKey) {
+        Order order = new Order(
+                buyer,
+                request.zipCode(),
+                request.baseAddress(),
+                request.detailAddress()
+        );
+        order.assignIdempotencyKey(normalizedIdempotencyKey);
+        return order;
+    }
+
+    private void appendOrderItems(Order order, List<CartItem> selectedCartItems, Map<Long, ProductInfo> productMap) {
+        for (CartItem cartItem : selectedCartItems) {
+            ProductInfo product = productMap.get(cartItem.getProductId());
+
+            if (product == null) {
+                log.warn("상품 정보를 찾을 수 없음: productId={}", cartItem.getProductId());
+                throw new CustomException(ErrorCode.CART_PRODUCT_INFO_NOT_FOUND);
+            }
+
+            if (product.getStock() < cartItem.getQuantity()) {
+                throw new CustomException(
+                        ErrorCode.CART_PRODUCT_OUT_OF_STOCK,
+                        String.format("%s 상품의 재고가 부족합니다. (필요: %d개, 재고: %d개)",
+                                product.getName(), cartItem.getQuantity(), product.getStock())
+                );
+            }
+
+            order.addItem(
+                    product.getSellerId(),
+                    product.getId(),
+                    product.getName(),
+                    product.getImageUrl(),
+                    product.getPrice(),
+                    product.getSalePrice(),
+                    cartItem.getQuantity()
+            );
+        }
     }
 }

--- a/market-service/src/main/java/com/thock/back/market/app/MarketFacade.java
+++ b/market-service/src/main/java/com/thock/back/market/app/MarketFacade.java
@@ -53,7 +53,12 @@ public class MarketFacade {
 
     @Transactional
     public OrderCreateResponse createOrder(Long memberId, OrderCreateRequest request) {
-        return marketCreateOrderUseCase.createOrder(memberId, request);
+        return marketCreateOrderUseCase.createOrder(memberId, request, null);
+    }
+
+    @Transactional
+    public OrderCreateResponse createOrder(Long memberId, OrderCreateRequest request, String idempotencyKey) {
+        return marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey);
     }
 
     @Transactional

--- a/market-service/src/main/java/com/thock/back/market/domain/Order.java
+++ b/market-service/src/main/java/com/thock/back/market/domain/Order.java
@@ -23,26 +23,38 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
-@Table(name = "market_orders")
+@Table(name = "market_orders",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_orders_buyer_id_idempotency_key",
+                        columnNames = {"buyer_id", "idempotency_key"}
+                )
+})
 @Getter
 @NoArgsConstructor
 @Slf4j
 public class Order extends BaseIdAndTime {
     @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "buyer_id", nullable = false)
     private MarketMember buyer;
 
     @Column(unique = true, nullable = false, length = 50)
     private String orderNumber;
+
+    @Column(name = "idempotency_key", length = 100)
+    private String idempotencyKey;
 
     @OneToMany(mappedBy = "order", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
     private List<OrderItem> items = new ArrayList<>();
@@ -222,16 +234,10 @@ public class Order extends BaseIdAndTime {
         if (isPaid()) {
             log.info("💸 환불 필요: orderId={}, refundAmount={}", getId(), totalSalePrice);
 
-            String cancelReason = cancelReasonType == CancelReasonType.ETC && cancelReasonDetail != null
-                    ? String.format("%s: %s", cancelReasonType.getDescription(), cancelReasonDetail)
-                    : cancelReasonType.getDescription();
-
-            PaymentCancelRequestDto cancelDto = new PaymentCancelRequestDto(
-                    this.orderNumber,
-                    String.format("주문 전체 취소 (사유: %s)", cancelReason),
-                    this.totalSalePrice  // 전액 환불
+            publishPaymentCancelRequest(
+                    String.format("주문 전체 취소 (사유: %s)", formatCancelReason(cancelReasonType, cancelReasonDetail)),
+                    this.totalSalePrice
             );
-            publishEvent(new MarketOrderPaymentRequestCanceledEvent(cancelDto));
         }
     }
 
@@ -239,26 +245,10 @@ public class Order extends BaseIdAndTime {
      * 부분 취소
      */
     public void cancelItems(List<Long> orderItemIds, CancelReasonType cancelReasonType, String cancelReasonDetail) {
-        // 1. 취소할 아이템들 조회 및 검증
-        // TODO : id가 unique이긴 하지만 findFirst가 뭔가 조금 어색함
-        List<OrderItem> orderItems = orderItemIds.stream()
-                .map(id -> items.stream()
-                        .filter(item -> item.getId().equals(id))
-                        .findFirst()
-                        .orElseThrow(() -> new CustomException(ErrorCode.ORDER_ITEM_NOT_FOUND)))
-                .toList();
+        List<OrderItem> orderItems = findOrderItemsByIds(orderItemIds);
+        validateCancellableItems(orderItems);
 
-        // 2. 취소 가능 상태 확인
-        orderItems.forEach(item -> {
-            if (!item.getState().isCancellable()) {
-                throw new CustomException(ErrorCode.ORDER_CANNOT_CANCEL);
-            }
-        });
-
-        // 3. 부분 환불 금액 계산
-        Long refundAmount = orderItems.stream()
-                .mapToLong(OrderItem::getTotalSalePrice)
-                .sum();
+        Long refundAmount = calculateRefundAmount(orderItems);
 
         // 4. 각 아이템 취소 처리
         orderItems.forEach(item -> item.cancel(cancelReasonType, cancelReasonDetail));
@@ -269,17 +259,14 @@ public class Order extends BaseIdAndTime {
 
         // 5. 결제 완료 후에만 환불 이벤트 (한 번만 발행)
         if (this.isPaid()) {
-            // ETC인 경우에만 사용자가 취소 사유 직접 입력 가능(선택)
-            String cancelReason = cancelReasonType == CancelReasonType.ETC && cancelReasonDetail != null
-                    ? String.format("%s: %s", cancelReasonType.getDescription(), cancelReasonDetail)
-                    : cancelReasonType.getDescription();
-
-            PaymentCancelRequestDto cancelDto = new PaymentCancelRequestDto(
-                    this.orderNumber,
-                    String.format("주문 상품 부분 취소 (%d개, 사유: %s)", orderItems.size(), cancelReason),
+            publishPaymentCancelRequest(
+                    String.format(
+                            "주문 상품 부분 취소 (%d개, 사유: %s)",
+                            orderItems.size(),
+                            formatCancelReason(cancelReasonType, cancelReasonDetail)
+                    ),
                     refundAmount
             );
-            publishEvent(new MarketOrderPaymentRequestCanceledEvent(cancelDto));
 
             log.info("💸 부분 환불 요청: orderId={}, refundAmount={}", getId(), refundAmount);
         }
@@ -377,20 +364,9 @@ public class Order extends BaseIdAndTime {
      * 부분 구매 확정
      */
     public void confirmItems(List<Long> orderItemIds) {
-        // 1. 확정할 아이템들 조회 및 검증
-        List<OrderItem> targetItems = orderItemIds.stream()
-                .map(id -> items.stream()
-                        .filter(item -> item.getId().equals(id))
-                        .findFirst()
-                        .orElseThrow(() -> new CustomException(ErrorCode.ORDER_ITEM_NOT_FOUND)))
-                .toList();
-        // 2. 각 아이템이 구매 확정 가능한 상태인지 확인
-        targetItems.forEach(item -> {
-            if (!item.getState().isConfirmable()) {
-                throw new CustomException(ErrorCode.ORDER_INVALID_STATE);
-            }
-        });
-        // 3. 각 아이템 구매 확정 처리
+        List<OrderItem> targetItems = findOrderItemsByIds(orderItemIds);
+        validateConfirmableItems(targetItems);
+
         targetItems.forEach(OrderItem::confirm);
 
         // 4. Order 상태 업데이트
@@ -421,15 +397,14 @@ public class Order extends BaseIdAndTime {
         }
 
         int totalItems = items.size();
-
-        // 각 상태별 카운트
-        long confirmedCount = countItemsByState(OrderItemState.CONFIRMED);
-        long cancelledCount = countItemsByState(OrderItemState.CANCELLED);
-        long refundedCount = countItemsByState(OrderItemState.REFUNDED);
-        long deliveredCount = countItemsByState(OrderItemState.DELIVERED);
-        long shippingCount = countItemsByState(OrderItemState.SHIPPING);
-        long preparingCount = countItemsByState(OrderItemState.PREPARING);
-        long paymentCompletedCount = countItemsByState(OrderItemState.PAYMENT_COMPLETED);
+        Map<OrderItemState, Long> stateCounts = buildStateCounts();
+        long confirmedCount = getStateCount(stateCounts, OrderItemState.CONFIRMED);
+        long cancelledCount = getStateCount(stateCounts, OrderItemState.CANCELLED);
+        long refundedCount = getStateCount(stateCounts, OrderItemState.REFUNDED);
+        long deliveredCount = getStateCount(stateCounts, OrderItemState.DELIVERED);
+        long shippingCount = getStateCount(stateCounts, OrderItemState.SHIPPING);
+        long preparingCount = getStateCount(stateCounts, OrderItemState.PREPARING);
+        long paymentCompletedCount = getStateCount(stateCounts, OrderItemState.PAYMENT_COMPLETED);
 
         // 취소/환불된 아이템 수
         long cancelledOrRefundedCount = cancelledCount + refundedCount;
@@ -473,8 +448,70 @@ public class Order extends BaseIdAndTime {
         }
     }
 
-    private long countItemsByState(OrderItemState state) {
-        return items.stream().filter(item -> item.getState() == state).count();
+    private List<OrderItem> findOrderItemsByIds(List<Long> orderItemIds) {
+        Map<Long, OrderItem> itemById = this.items.stream()
+                .collect(Collectors.toMap(OrderItem::getId, item -> item));
+
+        return orderItemIds.stream()
+                .map(id -> {
+                    OrderItem orderItem = itemById.get(id);
+                    if (orderItem == null) {
+                        throw new CustomException(ErrorCode.ORDER_ITEM_NOT_FOUND);
+                    }
+                    return orderItem;
+                })
+                .toList();
+    }
+
+    private void validateCancellableItems(List<OrderItem> orderItems) {
+        orderItems.forEach(item -> {
+            if (!item.getState().isCancellable()) {
+                throw new CustomException(ErrorCode.ORDER_CANNOT_CANCEL);
+            }
+        });
+    }
+
+    private void validateConfirmableItems(List<OrderItem> orderItems) {
+        orderItems.forEach(item -> {
+            if (!item.getState().isConfirmable()) {
+                throw new CustomException(ErrorCode.ORDER_INVALID_STATE);
+            }
+        });
+    }
+
+    private Long calculateRefundAmount(List<OrderItem> orderItems) {
+        return orderItems.stream()
+                .mapToLong(OrderItem::getTotalSalePrice)
+                .sum();
+    }
+
+    private String formatCancelReason(CancelReasonType cancelReasonType, String cancelReasonDetail) {
+        if (cancelReasonType == CancelReasonType.ETC && cancelReasonDetail != null) {
+            return String.format("%s: %s", cancelReasonType.getDescription(), cancelReasonDetail);
+        }
+        return cancelReasonType.getDescription();
+    }
+
+    private void publishPaymentCancelRequest(String cancelReasonMessage, Long cancelAmount) {
+        PaymentCancelRequestDto cancelDto = new PaymentCancelRequestDto(
+                this.orderNumber,
+                cancelReasonMessage,
+                cancelAmount
+        );
+        publishEvent(new MarketOrderPaymentRequestCanceledEvent(cancelDto));
+    }
+
+    private Map<OrderItemState, Long> buildStateCounts() {
+        return this.items.stream()
+                .collect(Collectors.groupingBy(
+                        OrderItem::getState,
+                        () -> new EnumMap<>(OrderItemState.class),
+                        Collectors.counting()
+                ));
+    }
+
+    private long getStateCount(Map<OrderItemState, Long> stateCounts, OrderItemState state) {
+        return stateCounts.getOrDefault(state, 0L);
     }
 
     public boolean isPaymentInProgress() {
@@ -527,5 +564,9 @@ public class Order extends BaseIdAndTime {
                 getOrderNumber(),
                 getTotalSalePrice()
         );
+    }
+
+    public void assignIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
     }
 }

--- a/market-service/src/main/java/com/thock/back/market/in/ApiV1OrderController.java
+++ b/market-service/src/main/java/com/thock/back/market/in/ApiV1OrderController.java
@@ -85,10 +85,12 @@ public class ApiV1OrderController {
     @PostMapping
     public ResponseEntity<OrderCreateResponse> createOrder(
             @AuthUser AuthenticatedUser user,
+            @RequestHeader(value = "X-Idempotency-Key", required = false) String idempotencyKey,
             @Valid @RequestBody OrderCreateRequest request) {
         Long memberId = user.memberId();
-        log.info("Market Order API : createOrder / memberId = {}", memberId);
-        OrderCreateResponse response = marketFacade.createOrder(memberId, request);
+        log.info("Market Order API : createOrder / memberId = {}, hasIdempotencyKey = {}",
+                memberId, idempotencyKey != null && !idempotencyKey.isBlank());
+        OrderCreateResponse response = marketFacade.createOrder(memberId, request, idempotencyKey);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/market-service/src/main/java/com/thock/back/market/out/repository/OrderRepository.java
+++ b/market-service/src/main/java/com/thock/back/market/out/repository/OrderRepository.java
@@ -11,11 +11,14 @@ import java.util.Optional;
 public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByOrderNumber(String orderName);
     List<Order> findByBuyerIdOrderByCreatedAtDesc(Long buyerId);
+
     // 타임아웃 스케줄러용: 결제 요청 후 N분 경과한 미결제 주문 조회
     List<Order> findByStateAndRequestPaymentDateBefore(OrderState state, LocalDateTime before);
 
     // 미결제 주문 존재 여부 확인 (중복 주문 방지용)
     boolean existsByBuyerIdAndState(Long buyerId, OrderState state);
+
+    Optional<Order> findByBuyerIdAndIdempotencyKey(Long buyerId, String idempotencyKey);
 
     // 취소 상태의 주문 며칠 지났는지 확인용 / 30일 지났을 시 배치 처리
     List<Order> findByStateAndCancelDateBefore(OrderState state, LocalDateTime before);

--- a/market-service/src/main/resources/db/migration/V1__add_order_idempotency_unique_constraint.sql
+++ b/market-service/src/main/resources/db/migration/V1__add_order_idempotency_unique_constraint.sql
@@ -1,0 +1,40 @@
+ALTER TABLE market_orders
+    MODIFY COLUMN buyer_id BIGINT NOT NULL;
+
+-- idempotency_key 없을 때만 추가
+SET @add_idempotency_key = (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'market_orders'
+              AND COLUMN_NAME = 'idempotency_key'
+        ),
+        'SELECT 1',
+        'ALTER TABLE market_orders ADD COLUMN idempotency_key VARCHAR(100) NULL'
+    )
+);
+
+PREPARE stmt FROM @add_idempotency_key;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- 복합 유니크 없을때만 추가
+SET @add_unique_constraint = (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.STATISTICS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'market_orders'
+              AND INDEX_NAME = 'uk_orders_buyer_id_idempotency_key'
+        ),
+        'SELECT 1',
+        'ALTER TABLE market_orders ADD CONSTRAINT uk_orders_buyer_id_idempotency_key UNIQUE (buyer_id, idempotency_key)'
+    )
+);
+
+PREPARE stmt FROM @add_unique_constraint;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/market-service/src/test/java/com/thock/back/market/app/MarketCreateOrderUseCaseTest.java
+++ b/market-service/src/test/java/com/thock/back/market/app/MarketCreateOrderUseCaseTest.java
@@ -4,6 +4,7 @@ import com.thock.back.global.exception.CustomException;
 import com.thock.back.global.exception.ErrorCode;
 import com.thock.back.market.domain.Cart;
 import com.thock.back.market.domain.MarketMember;
+import com.thock.back.market.domain.MarketPolicy;
 import com.thock.back.market.domain.Order;
 import com.thock.back.market.domain.OrderState;
 import com.thock.back.market.in.dto.req.OrderCreateRequest;
@@ -21,6 +22,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -160,7 +162,6 @@ class MarketCreateOrderUseCaseTest {
             Order existingOrder = new Order(buyer, "12345", "서울시 강남구", "101호");
             existingOrder.assignIdempotencyKey(idempotencyKey);
 
-            given(buyer.getId()).willReturn(memberId);
             given(marketMemberRepository.findByIdForUpdate(memberId)).willReturn(Optional.of(buyer));
             given(orderRepository.findByBuyerIdAndIdempotencyKey(memberId, idempotencyKey))
                     .willReturn(Optional.of(existingOrder));
@@ -179,6 +180,7 @@ class MarketCreateOrderUseCaseTest {
         void createOrder_uniqueConstraintConflict_returnsExistingOrder() {
             Long memberId = 1L;
             String idempotencyKey = "order-create-1";
+            MarketPolicy.PRODUCT_PAYOUT_RATE = 90.0;
             OrderCreateRequest request = new OrderCreateRequest(
                     List.of(1L),
                     "12345",
@@ -186,8 +188,11 @@ class MarketCreateOrderUseCaseTest {
                     "101호"
             );
 
+            given(buyer.getId()).willReturn(memberId);
+
             Cart cart = new Cart(buyer);
             cart.addItem(10L, 1);
+            ReflectionTestUtils.setField(cart.getItems().get(0), "id", 1L);
 
             ProductInfo productInfo = new ProductInfo(
                     10L,
@@ -212,7 +217,6 @@ class MarketCreateOrderUseCaseTest {
                     1
             );
 
-            given(buyer.getId()).willReturn(memberId);
             given(marketMemberRepository.findByIdForUpdate(memberId)).willReturn(Optional.of(buyer));
             given(orderRepository.findByBuyerIdAndIdempotencyKey(memberId, idempotencyKey))
                     .willReturn(Optional.empty(), Optional.of(existingOrder));

--- a/market-service/src/test/java/com/thock/back/market/app/MarketCreateOrderUseCaseTest.java
+++ b/market-service/src/test/java/com/thock/back/market/app/MarketCreateOrderUseCaseTest.java
@@ -2,9 +2,14 @@ package com.thock.back.market.app;
 
 import com.thock.back.global.exception.CustomException;
 import com.thock.back.global.exception.ErrorCode;
+import com.thock.back.market.domain.Cart;
 import com.thock.back.market.domain.MarketMember;
+import com.thock.back.market.domain.Order;
 import com.thock.back.market.domain.OrderState;
 import com.thock.back.market.in.dto.req.OrderCreateRequest;
+import com.thock.back.market.in.dto.res.OrderCreateResponse;
+import com.thock.back.market.out.api.dto.ProductInfo;
+import com.thock.back.market.out.api.dto.WalletInfo;
 import com.thock.back.market.out.repository.CartRepository;
 import com.thock.back.market.out.repository.MarketMemberRepository;
 import com.thock.back.market.out.repository.OrderRepository;
@@ -15,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.List;
 import java.util.Optional;
@@ -137,6 +143,91 @@ class MarketCreateOrderUseCaseTest {
                         assertThat(customException.getErrorCode().getMessage())
                                 .isEqualTo("이미 결제 대기 중인 주문이 있습니다.");
                     });
+        }
+
+        @Test
+        @DisplayName("같은 멱등 키 재요청이면 기존 주문을 반환한다")
+        void createOrder_sameIdempotencyKey_returnsExistingOrder() {
+            Long memberId = 1L;
+            String idempotencyKey = "order-create-1";
+            OrderCreateRequest request = new OrderCreateRequest(
+                    List.of(1L),
+                    "12345",
+                    "서울시 강남구",
+                    "101호"
+            );
+
+            Order existingOrder = new Order(buyer, "12345", "서울시 강남구", "101호");
+            existingOrder.assignIdempotencyKey(idempotencyKey);
+
+            given(buyer.getId()).willReturn(memberId);
+            given(marketMemberRepository.findByIdForUpdate(memberId)).willReturn(Optional.of(buyer));
+            given(orderRepository.findByBuyerIdAndIdempotencyKey(memberId, idempotencyKey))
+                    .willReturn(Optional.of(existingOrder));
+            given(marketSupport.getWallet(memberId)).willReturn(new WalletInfo(1_000L));
+
+            OrderCreateResponse response = marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey);
+
+            assertThat(response.orderNumber()).isEqualTo(existingOrder.getOrderNumber());
+            assertThat(response.pgAmount()).isEqualTo(0L);
+            verify(orderRepository, never()).existsByBuyerIdAndState(any(), any());
+            verify(cartRepository, never()).findByBuyer(any());
+        }
+
+        @Test
+        @DisplayName("동시 요청으로 유니크 충돌이 나면 기존 주문을 반환한다")
+        void createOrder_uniqueConstraintConflict_returnsExistingOrder() {
+            Long memberId = 1L;
+            String idempotencyKey = "order-create-1";
+            OrderCreateRequest request = new OrderCreateRequest(
+                    List.of(1L),
+                    "12345",
+                    "서울시 강남구",
+                    "101호"
+            );
+
+            Cart cart = new Cart(buyer);
+            cart.addItem(10L, 1);
+
+            ProductInfo productInfo = new ProductInfo(
+                    10L,
+                    2L,
+                    "기계식 키보드",
+                    "keyboard.jpg",
+                    50_000L,
+                    40_000L,
+                    10,
+                    "ON_SALE"
+            );
+
+            Order existingOrder = new Order(buyer, "12345", "서울시 강남구", "101호");
+            existingOrder.assignIdempotencyKey(idempotencyKey);
+            existingOrder.addItem(
+                    2L,
+                    10L,
+                    "기계식 키보드",
+                    "keyboard.jpg",
+                    50_000L,
+                    40_000L,
+                    1
+            );
+
+            given(buyer.getId()).willReturn(memberId);
+            given(marketMemberRepository.findByIdForUpdate(memberId)).willReturn(Optional.of(buyer));
+            given(orderRepository.findByBuyerIdAndIdempotencyKey(memberId, idempotencyKey))
+                    .willReturn(Optional.empty(), Optional.of(existingOrder));
+            given(orderRepository.existsByBuyerIdAndState(memberId, OrderState.PENDING_PAYMENT))
+                    .willReturn(false);
+            given(cartRepository.findByBuyer(buyer)).willReturn(Optional.of(cart));
+            given(marketSupport.getProducts(List.of(10L))).willReturn(List.of(productInfo));
+            given(orderRepository.saveAndFlush(any(Order.class)))
+                    .willThrow(new DataIntegrityViolationException("unique constraint violation"));
+            given(marketSupport.getWallet(memberId)).willReturn(new WalletInfo(5_000L));
+
+            OrderCreateResponse response = marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey);
+
+            assertThat(response.orderNumber()).isEqualTo(existingOrder.getOrderNumber());
+            assertThat(response.pgAmount()).isEqualTo(35_000L);
         }
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
- #403 

## 📝 작업 내용
- 멱등성 키 도입

- DB unique 제약 조건 추가 (동시에 들어오는 요청 중복 방지)

- 애플리케이션 레벨에서 동시 요청에 대한 멱등성 있는 반환을 위해 saveAndFlush 사용
DataIntegrityViolationException 발생 시 멱등한 결과 반환

- 엔티티 수정으로 인해 flyway V1 파일 추가

### 🧪 테스트 (검증/실행 방법/결과)
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [ ] 로컬에서 테스트 완료
- [ ] Postman/Swagger 테스트 완료

### 📸 스크린샷 (선택사항)
<img width="1096" height="64" alt="스크린샷 2026-03-25 오전 7 28 40" src="https://github.com/user-attachments/assets/33642fad-ec0a-4c2d-af39-d735194e68a1" />


## 📋 리뷰 요청 사항 (선택사항)
리뷰어가 특히 봐주었으면 하는 부분을 적어주세요.
- 
-

## 📚 참고 자료 (선택사항)
관련 문서나 레퍼런스가 있다면 링크를 추가해주세요.
- 
-


