### PR TITLE
[FIX] #405 동시 주문 요청 시 멱등성 키 유니크 충돌로 인한 UnexpectedRollbackException 해결

### DIFF
--- a/common/src/main/java/com/thock/back/global/exception/ErrorCode.java
+++ b/common/src/main/java/com/thock/back/global/exception/ErrorCode.java
@@ -85,6 +85,7 @@ public enum ErrorCode {
     ORDER_CANNOT_CANCEL("ORDER-400-3", "주문 취소가 불가능한 상태입니다.", HttpStatus.BAD_REQUEST),
     ORDER_CANNOT_REFUND("ORDER-400-4", "환불이 불가능한 상태입니다.", HttpStatus.BAD_REQUEST),
     ORDER_NO_ITEMS_SELECTED("ORDER-400-5    ", "주문할 상품을 선택해주세요.", HttpStatus.BAD_REQUEST),
+    ORDER_IDEMPOTENCY_KEY_REQUIRED("ORDER-400-6", "멱등성 키는 필수입니다.", HttpStatus.BAD_REQUEST),
     ORDER_USER_FORBIDDEN("ORDER-403-1", "주문 취소할 권한이 없습니다.", HttpStatus.FORBIDDEN),
     ORDER_ACCESS_DENIED("ORDER-403-2", "본인의 주문이 아닙니다.", HttpStatus.FORBIDDEN),
     ORDER_NOT_FOUND("ORDER-404-1", "주문을 찾을 수 없습니다", HttpStatus.NOT_FOUND),

--- a/market-service/src/main/java/com/thock/back/market/app/MarketCreateOrderUseCase.java
+++ b/market-service/src/main/java/com/thock/back/market/app/MarketCreateOrderUseCase.java
@@ -16,7 +16,6 @@ import com.thock.back.market.out.repository.MarketMemberRepository;
 import com.thock.back.market.out.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,22 +33,36 @@ public class MarketCreateOrderUseCase {
     private final CartRepository cartRepository;
     private final MarketSupport marketSupport; // 조회 전용
 
-    // 주문 생성 - 장바구니 내 선택한 상품들만 주문에 들어감
-    @Transactional
-    public OrderCreateResponse createOrder(Long memberId, OrderCreateRequest request) {
-        return createOrder(memberId, request, null);
-    }
-
-    @Transactional
-    public OrderCreateResponse createOrder(Long memberId, OrderCreateRequest request, String idempotencyKey) {
+    // Facade에서 접근해야 하므로 public으로 열고 읽기 전용 트랜잭션 적용
+    @Transactional(readOnly = true)
+    public OrderCreateResponse findExistingOrderByIdempotencyKey(Long memberId, String idempotencyKey) {
+        // 조회 시에는 키가 없으면 그냥 null 반환 (예외 X)
         String normalizedIdempotencyKey = normalizeIdempotencyKey(idempotencyKey);
-        MarketMember buyer = getBuyerForUpdate(memberId);
-
-        OrderCreateResponse idempotentResponse = findExistingOrderByIdempotencyKey(memberId, normalizedIdempotencyKey);
-        if (idempotentResponse != null) {
-            return idempotentResponse;
+        if (normalizedIdempotencyKey == null) {
+            return null;
         }
 
+        return orderRepository.findByBuyerIdAndIdempotencyKey(memberId, normalizedIdempotencyKey)
+                .map(order -> {
+                    log.info("멱등 키 재요청 감지: memberId={}, orderId={}, orderNumber={}",
+                            memberId, order.getId(), order.getOrderNumber());
+
+                    // TODO: 향후 Order 엔티티에 결제 금액을 캐싱하여 지갑(Wallet) 외부 API 호출 의존성 제거 고려
+                    WalletInfo wallet = marketSupport.getWallet(memberId);
+                    Long balance = wallet.getBalance();
+                    Long pgAmount = Math.max(0L, order.getTotalSalePrice() - balance);
+                    return OrderCreateResponse.from(order, pgAmount);
+                })
+                .orElse(null);
+    }
+
+    // Facade에서 호출하는 실제 생성 로직
+    @Transactional
+    public OrderCreateResponse createOrder(Long memberId, OrderCreateRequest request, String idempotencyKey) {
+        // 생성 진입점에서는 멱등성 키 필수 검증 (없으면 예외)
+        String normalizedIdempotencyKey = validateAndNormalizeIdempotencyKey(idempotencyKey);
+
+        MarketMember buyer = getBuyerForUpdate(memberId);
         validateNoPendingOrder(memberId);
 
         Cart cart = getCartByBuyer(buyer);
@@ -59,31 +72,7 @@ public class MarketCreateOrderUseCase {
         Order order = createOrderAggregate(buyer, request, normalizedIdempotencyKey);
         appendOrderItems(order, selectedCartItems, productMap);
 
-        Order savedOrder;
-
-        try {
-            savedOrder = orderRepository.saveAndFlush(order);
-        } catch (DataIntegrityViolationException e) {
-            if (normalizedIdempotencyKey == null) {
-                throw e;
-            }
-
-            log.info("멱등 키 유니크 충돌 감지: memberId={}, idempotencyKey={}",
-                    memberId, normalizedIdempotencyKey);
-
-            return orderRepository.findByBuyerIdAndIdempotencyKey(memberId,
-                            normalizedIdempotencyKey)
-                    .map(existingOrder -> {
-                        WalletInfo wallet = marketSupport.getWallet(buyer.getId());
-                        Long balance = wallet.getBalance();
-                        Long pgAmount = Math.max(0L, existingOrder.getTotalSalePrice() -
-                                balance);
-                        return OrderCreateResponse.from(existingOrder, pgAmount);
-                    })
-                    .orElseThrow(() -> e);
-        }
-
-
+        Order savedOrder = orderRepository.saveAndFlush(order);
 
         WalletInfo wallet = marketSupport.getWallet(buyer.getId());
         Long balance = wallet.getBalance();
@@ -98,38 +87,29 @@ public class MarketCreateOrderUseCase {
                 savedOrder.getTotalSalePrice(),
                 savedOrder.getItems().size());
 
-        // 11. 응답 생성 및 반환
         return OrderCreateResponse.from(savedOrder, pgAmount);
     }
 
+    // 단순 정규화 (null 반환 허용 - 조회용)
     private String normalizeIdempotencyKey(String idempotencyKey) {
-        if (idempotencyKey == null) {
+        if (idempotencyKey == null || idempotencyKey.trim().isEmpty()) {
             return null;
         }
-        String trimmed = idempotencyKey.trim();
-        return trimmed.isEmpty() ? null : trimmed;
+        return idempotencyKey.trim();
+    }
+
+    // 정규화 + 필수값 검증 (예외 발생 - 생성용)
+    private String validateAndNormalizeIdempotencyKey(String idempotencyKey) {
+        String normalized = normalizeIdempotencyKey(idempotencyKey);
+        if (normalized == null) {
+            throw new CustomException(ErrorCode.ORDER_IDEMPOTENCY_KEY_REQUIRED);
+        }
+        return normalized;
     }
 
     private MarketMember getBuyerForUpdate(Long memberId) {
         return marketMemberRepository.findByIdForUpdate(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CART_USER_NOT_FOUND));
-    }
-
-    private OrderCreateResponse findExistingOrderByIdempotencyKey(Long memberId, String normalizedIdempotencyKey) {
-        if (normalizedIdempotencyKey == null) {
-            return null;
-        }
-
-        return orderRepository.findByBuyerIdAndIdempotencyKey(memberId, normalizedIdempotencyKey)
-                .map(order -> {
-                    log.info("멱등 키 재요청 감지: memberId={}, orderId={}, orderNumber={}",
-                            memberId, order.getId(), order.getOrderNumber());
-                    WalletInfo wallet = marketSupport.getWallet(memberId);
-                    Long balance = wallet.getBalance();
-                    Long pgAmount = Math.max(0L, order.getTotalSalePrice() - balance);
-                    return OrderCreateResponse.from(order, pgAmount);
-                })
-                .orElse(null);
     }
 
     private void validateNoPendingOrder(Long memberId) {

--- a/market-service/src/main/java/com/thock/back/market/app/MarketFacade.java
+++ b/market-service/src/main/java/com/thock/back/market/app/MarketFacade.java
@@ -10,6 +10,7 @@ import com.thock.back.market.in.dto.res.OrderCreateResponse;
 import com.thock.back.market.in.dto.res.OrderDetailResponse;
 import com.thock.back.shared.market.domain.CancelReasonType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,14 +52,32 @@ public class MarketFacade {
         return cartService.addCartItem(memberId, request);
     }
 
-    @Transactional
-    public OrderCreateResponse createOrder(Long memberId, OrderCreateRequest request) {
-        return marketCreateOrderUseCase.createOrder(memberId, request, null);
-    }
-
-    @Transactional
+    // 주문 생성 로직 (트랜잭션 분리: 멱등성 키 충돌(DataIntegrityViolationException) 시
+    // 예외를 잡아서 복구하기 위해 Facade 계층에서는 트랜잭션을 열지 않음)
     public OrderCreateResponse createOrder(Long memberId, OrderCreateRequest request, String idempotencyKey) {
-        return marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey);
+        // 1. 트랜잭션 시작 전, 멱등성 키로 기존 주문 확인
+        OrderCreateResponse existingOrder = marketCreateOrderUseCase.findExistingOrderByIdempotencyKey(memberId, idempotencyKey);
+        // 순차 요청에 대한 중복 주문 생성 방지 - ex) 3초 뒤에 다시 버튼 클릭
+        if (existingOrder != null) {
+            return existingOrder; // 기존 주문을 반환
+        }
+
+        try {
+            // 2. 실제 주문 생성 (이 내부에서 @Transactional이 동작하여 새로운 트랜잭션 시작/종료)
+            return marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey);
+        }
+        // 동시 요청에 대한 중복 주문 생성 방지 - ex) 순간적으로 2번 클릭 or 여러 브라우저 띄워놓고 동시에 요청
+        catch (DataIntegrityViolationException e) {
+            // 3. DB 유니크 제약조건(멱등성 키 중복) 충돌 발생 시
+            // UseCase의 트랜잭션은 롤백되었지만, Facade는 트랜잭션 밖이므로 UnexpectedRollbackException 터질 일이 없음
+            OrderCreateResponse retryExistingOrder = marketCreateOrderUseCase.findExistingOrderByIdempotencyKey(memberId, idempotencyKey);
+
+            if (retryExistingOrder != null) {
+                return retryExistingOrder;
+            }
+            // 정말 알 수 없는 무결성 위반이라면 예외 다시 던지기
+            throw e;
+        }
     }
 
     @Transactional

--- a/market-service/src/main/java/com/thock/back/market/in/ApiV1OrderController.java
+++ b/market-service/src/main/java/com/thock/back/market/in/ApiV1OrderController.java
@@ -85,7 +85,7 @@ public class ApiV1OrderController {
     @PostMapping
     public ResponseEntity<OrderCreateResponse> createOrder(
             @AuthUser AuthenticatedUser user,
-            @RequestHeader(value = "X-Idempotency-Key", required = false) String idempotencyKey,
+            @RequestHeader(value = "X-Idempotency-Key") String idempotencyKey,
             @Valid @RequestBody OrderCreateRequest request) {
         Long memberId = user.memberId();
         log.info("Market Order API : createOrder / memberId = {}, hasIdempotencyKey = {}",

--- a/market-service/src/main/resources/application-test.yml
+++ b/market-service/src/main/resources/application-test.yml
@@ -37,3 +37,7 @@ jwt:
   access-token-exp-seconds: 1800
   refresh-token-exp-seconds: 1209600
   issuer: "thock"
+
+market:
+  metrics:
+    enabled: false

--- a/market-service/src/test/java/com/thock/back/market/app/MarketCreateOrderUnexpectedRollbackIntegrationTest.java
+++ b/market-service/src/test/java/com/thock/back/market/app/MarketCreateOrderUnexpectedRollbackIntegrationTest.java
@@ -1,178 +1,96 @@
 package com.thock.back.market.app;
 
-import com.thock.back.market.domain.Cart;
-import com.thock.back.market.domain.MarketMember;
-import com.thock.back.market.domain.MarketPolicy;
-import com.thock.back.market.domain.Order;
 import com.thock.back.market.domain.OrderState;
 import com.thock.back.market.in.dto.req.OrderCreateRequest;
 import com.thock.back.market.in.dto.res.OrderCreateResponse;
-import com.thock.back.market.out.api.dto.ProductInfo;
-import com.thock.back.market.out.api.dto.WalletInfo;
-import com.thock.back.market.out.client.PaymentWalletClient;
-import com.thock.back.market.out.client.ProductClient;
-import com.thock.back.market.out.repository.CartRepository;
-import com.thock.back.market.out.repository.MarketMemberRepository;
-import com.thock.back.market.out.repository.OrderRepository;
-import com.thock.back.shared.member.domain.MemberRole;
-import com.thock.back.shared.member.domain.MemberState;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-@SpringBootTest(properties = {
-        "spring.datasource.url=jdbc:h2:mem:market-it;MODE=MySQL;DB_CLOSE_DELAY=-1",
-        "spring.datasource.driver-class-name=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.datasource.password=",
-        "spring.jpa.hibernate.ddl-auto=create-drop",
-        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
-        "spring.flyway.enabled=false"
-})
-@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
 class MarketCreateOrderUnexpectedRollbackIntegrationTest {
 
-    private static final Logger log = LoggerFactory.getLogger(MarketCreateOrderUnexpectedRollbackIntegrationTest.class);
-
-    @Autowired
+    @InjectMocks
     private MarketFacade marketFacade;
 
-    @Autowired
-    private MarketMemberRepository marketMemberRepository;
+    @Mock
+    private MarketSyncMemberUseCase marketSyncMemberUseCase;
 
-    @Autowired
-    private CartRepository cartRepository;
+    @Mock
+    private MarketCreateCartUseCase marketCreateCartUseCase;
 
-    @Autowired
-    private OrderRepository orderRepository;
+    @Mock
+    private MarketCreateOrderUseCase marketCreateOrderUseCase;
 
-    @Autowired
-    private JdbcTemplate jdbcTemplate;
+    @Mock
+    private MarketCompleteOrderPaymentUseCase marketCompleteOrderPaymentUseCase;
 
-    @MockitoSpyBean
-    private OrderRepository spyOrderRepository;
+    @Mock
+    private MarketCancelOrderPaymentUseCase marketCancelOrderPaymentUseCase;
 
-    @MockitoBean
-    private ProductClient productClient;
+    @Mock
+    private MarketCompleteRefundUseCase marketCompleteRefundUseCase;
 
-    @MockitoBean
-    private PaymentWalletClient paymentWalletClient;
+    @Mock
+    private MarketConfirmOrderUseCase marketConfirmOrderUseCase;
 
-    @BeforeEach
-    void setUp() {
-        orderRepository.deleteAll();
-        cartRepository.deleteAll();
-        marketMemberRepository.deleteAll();
-    }
+    @Mock
+    private CartService cartService;
+
+    @Mock
+    private OrderService orderService;
 
     @Test
     @DisplayName("동시 요청으로 unique 충돌이 발생해도 UnexpectedRollbackException 없이 기존 주문을 반환한다")
-    void createOrder_uniqueConflict_doesNotThrowUnexpectedRollbackException_andReturnsExistingOrder() throws Exception {
+    void createOrder_uniqueConflict_doesNotThrowUnexpectedRollbackException_andReturnsExistingOrder() {
         Long memberId = 1L;
         String idempotencyKey = "idem-key-1";
-
-        MarketMember buyer = new MarketMember(
-                "buyer@test.com",
-                "buyer",
-                MemberRole.USER,
-                MemberState.ACTIVE,
-                memberId,
-                LocalDateTime.now(),
-                LocalDateTime.now()
-        );
-        marketMemberRepository.saveAndFlush(buyer);
-
-        jdbcTemplate.update(
-                "insert into market_carts (id, buyer_id, items_count, created_at, updated_at) values (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-                memberId,
-                memberId,
-                1
-        );
-        jdbcTemplate.update(
-                "insert into market_cart_items (cart_id, product_id, quantity, created_at, updated_at) values (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-                memberId,
-                10L,
-                1
-        );
-
-        Long cartItemId = jdbcTemplate.queryForObject(
-                "select id from market_cart_items where cart_id = ?",
-                Long.class,
-                memberId
-        );
-
-        Order existingOrder = new Order(buyer, "12345", "서울시 강남구", "101호");
-        existingOrder.assignIdempotencyKey(idempotencyKey);
-        ReflectionTestUtils.setField(existingOrder, "state", OrderState.CANCELLED);
-        orderRepository.saveAndFlush(existingOrder);
-
-        MarketPolicy.PRODUCT_PAYOUT_RATE = 90.0;
-
-        given(productClient.getProducts(anyList())).willReturn(List.of(
-                new ProductInfo(
-                        10L,
-                        2L,
-                        "기계식 키보드",
-                        "keyboard.jpg",
-                        50_000L,
-                        40_000L,
-                        10,
-                        "ON_SALE"
-                )
-        ));
-        given(paymentWalletClient.getWallet(eq(memberId))).willReturn(new WalletInfo(0L));
-
-        AtomicInteger lookupCount = new AtomicInteger();
-        doAnswer(invocation -> {
-            Long buyerArg = invocation.getArgument(0);
-            String keyArg = invocation.getArgument(1);
-
-            if (lookupCount.getAndIncrement() == 0) {
-                return Optional.empty();
-            }
-            Long orderId = jdbcTemplate.queryForObject(
-                    "select id from market_orders where buyer_id = ? and idempotency_key = ?",
-                    Long.class,
-                    buyerArg,
-                    keyArg
-            );
-            return orderRepository.findById(orderId);
-        }).when(spyOrderRepository).findByBuyerIdAndIdempotencyKey(memberId, idempotencyKey);
-
         OrderCreateRequest request = new OrderCreateRequest(
-                List.of(cartItemId),
+                List.of(1L),
                 "12345",
                 "서울시 강남구",
                 "101호"
         );
 
+        OrderCreateResponse existingOrder = new OrderCreateResponse(
+                1L,
+                "ORDER-20260403-TEST",
+                OrderState.PENDING_PAYMENT,
+                List.of(),
+                50_000L,
+                40_000L,
+                10_000L,
+                40_000L,
+                "12345",
+                "서울시 강남구",
+                "101호",
+                LocalDateTime.now()
+        );
+
+        given(marketCreateOrderUseCase.findExistingOrderByIdempotencyKey(memberId, idempotencyKey))
+                .willReturn(null, existingOrder);
+        given(marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey))
+                .willThrow(new DataIntegrityViolationException("unique constraint violation"));
+
         // 과거에는 같은 트랜잭션 내부에서 예외를 복구하려다 UnexpectedRollbackException이 발생했지만,
         // 현재는 Facade가 비트랜잭션으로 동작하므로 기존 주문 응답으로 정상 복구되어야 한다.
         OrderCreateResponse response = marketFacade.createOrder(memberId, request, idempotencyKey);
 
-        assertThat(response.orderNumber()).isEqualTo(existingOrder.getOrderNumber());
-        assertThat(response.pgAmount()).isEqualTo(existingOrder.getTotalSalePrice());
-        log.info("Recovered existing order after unique conflict: orderNumber={}", response.orderNumber());
-
+        assertThat(response).isEqualTo(existingOrder);
+        verify(marketCreateOrderUseCase).createOrder(memberId, request, idempotencyKey);
+        verify(marketCreateOrderUseCase, times(2))
+                .findExistingOrderByIdempotencyKey(memberId, idempotencyKey);
     }
 }

--- a/market-service/src/test/java/com/thock/back/market/app/MarketCreateOrderUnexpectedRollbackIntegrationTest.java
+++ b/market-service/src/test/java/com/thock/back/market/app/MarketCreateOrderUnexpectedRollbackIntegrationTest.java
@@ -1,0 +1,178 @@
+package com.thock.back.market.app;
+
+import com.thock.back.market.domain.Cart;
+import com.thock.back.market.domain.MarketMember;
+import com.thock.back.market.domain.MarketPolicy;
+import com.thock.back.market.domain.Order;
+import com.thock.back.market.domain.OrderState;
+import com.thock.back.market.in.dto.req.OrderCreateRequest;
+import com.thock.back.market.in.dto.res.OrderCreateResponse;
+import com.thock.back.market.out.api.dto.ProductInfo;
+import com.thock.back.market.out.api.dto.WalletInfo;
+import com.thock.back.market.out.client.PaymentWalletClient;
+import com.thock.back.market.out.client.ProductClient;
+import com.thock.back.market.out.repository.CartRepository;
+import com.thock.back.market.out.repository.MarketMemberRepository;
+import com.thock.back.market.out.repository.OrderRepository;
+import com.thock.back.shared.member.domain.MemberRole;
+import com.thock.back.shared.member.domain.MemberState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:market-it;MODE=MySQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+        "spring.flyway.enabled=false"
+})
+@ActiveProfiles("test")
+class MarketCreateOrderUnexpectedRollbackIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(MarketCreateOrderUnexpectedRollbackIntegrationTest.class);
+
+    @Autowired
+    private MarketFacade marketFacade;
+
+    @Autowired
+    private MarketMemberRepository marketMemberRepository;
+
+    @Autowired
+    private CartRepository cartRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoSpyBean
+    private OrderRepository spyOrderRepository;
+
+    @MockitoBean
+    private ProductClient productClient;
+
+    @MockitoBean
+    private PaymentWalletClient paymentWalletClient;
+
+    @BeforeEach
+    void setUp() {
+        orderRepository.deleteAll();
+        cartRepository.deleteAll();
+        marketMemberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("동시 요청으로 unique 충돌이 발생해도 UnexpectedRollbackException 없이 기존 주문을 반환한다")
+    void createOrder_uniqueConflict_doesNotThrowUnexpectedRollbackException_andReturnsExistingOrder() throws Exception {
+        Long memberId = 1L;
+        String idempotencyKey = "idem-key-1";
+
+        MarketMember buyer = new MarketMember(
+                "buyer@test.com",
+                "buyer",
+                MemberRole.USER,
+                MemberState.ACTIVE,
+                memberId,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+        marketMemberRepository.saveAndFlush(buyer);
+
+        jdbcTemplate.update(
+                "insert into market_carts (id, buyer_id, items_count, created_at, updated_at) values (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                memberId,
+                memberId,
+                1
+        );
+        jdbcTemplate.update(
+                "insert into market_cart_items (cart_id, product_id, quantity, created_at, updated_at) values (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                memberId,
+                10L,
+                1
+        );
+
+        Long cartItemId = jdbcTemplate.queryForObject(
+                "select id from market_cart_items where cart_id = ?",
+                Long.class,
+                memberId
+        );
+
+        Order existingOrder = new Order(buyer, "12345", "서울시 강남구", "101호");
+        existingOrder.assignIdempotencyKey(idempotencyKey);
+        ReflectionTestUtils.setField(existingOrder, "state", OrderState.CANCELLED);
+        orderRepository.saveAndFlush(existingOrder);
+
+        MarketPolicy.PRODUCT_PAYOUT_RATE = 90.0;
+
+        given(productClient.getProducts(anyList())).willReturn(List.of(
+                new ProductInfo(
+                        10L,
+                        2L,
+                        "기계식 키보드",
+                        "keyboard.jpg",
+                        50_000L,
+                        40_000L,
+                        10,
+                        "ON_SALE"
+                )
+        ));
+        given(paymentWalletClient.getWallet(eq(memberId))).willReturn(new WalletInfo(0L));
+
+        AtomicInteger lookupCount = new AtomicInteger();
+        doAnswer(invocation -> {
+            Long buyerArg = invocation.getArgument(0);
+            String keyArg = invocation.getArgument(1);
+
+            if (lookupCount.getAndIncrement() == 0) {
+                return Optional.empty();
+            }
+            Long orderId = jdbcTemplate.queryForObject(
+                    "select id from market_orders where buyer_id = ? and idempotency_key = ?",
+                    Long.class,
+                    buyerArg,
+                    keyArg
+            );
+            return orderRepository.findById(orderId);
+        }).when(spyOrderRepository).findByBuyerIdAndIdempotencyKey(memberId, idempotencyKey);
+
+        OrderCreateRequest request = new OrderCreateRequest(
+                List.of(cartItemId),
+                "12345",
+                "서울시 강남구",
+                "101호"
+        );
+
+        // 과거에는 같은 트랜잭션 내부에서 예외를 복구하려다 UnexpectedRollbackException이 발생했지만,
+        // 현재는 Facade가 비트랜잭션으로 동작하므로 기존 주문 응답으로 정상 복구되어야 한다.
+        OrderCreateResponse response = marketFacade.createOrder(memberId, request, idempotencyKey);
+
+        assertThat(response.orderNumber()).isEqualTo(existingOrder.getOrderNumber());
+        assertThat(response.pgAmount()).isEqualTo(existingOrder.getTotalSalePrice());
+        log.info("Recovered existing order after unique conflict: orderNumber={}", response.orderNumber());
+
+    }
+}

--- a/market-service/src/test/java/com/thock/back/market/app/MarketCreateOrderUseCaseTest.java
+++ b/market-service/src/test/java/com/thock/back/market/app/MarketCreateOrderUseCaseTest.java
@@ -59,6 +59,8 @@ class MarketCreateOrderUseCaseTest {
     @DisplayName("주문 무한 생성 방지 테스트")
     class PreventInfiniteOrderCreationTest {
 
+        private final String idempotencyKey = "order-create-1";
+
         @Test
         @DisplayName("미결제 주문이 이미 존재하면 ORDER_PENDING_EXISTS 예외가 발생한다")
         void createOrder_pendingOrderExists_throwsException() {
@@ -76,7 +78,7 @@ class MarketCreateOrderUseCaseTest {
                     .willReturn(true); // 이미 미결제 주문 존재
 
             // when & then
-            assertThatThrownBy(() -> marketCreateOrderUseCase.createOrder(memberId, request))
+            assertThatThrownBy(() -> marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey))
                     .isInstanceOf(CustomException.class)
                     .satisfies(ex -> {
                         CustomException customException = (CustomException) ex;
@@ -105,7 +107,7 @@ class MarketCreateOrderUseCaseTest {
             given(cartRepository.findByBuyer(buyer)).willReturn(Optional.empty());
 
             // when & then - 장바구니 없음 예외 발생 (정상 흐름 진행 확인용)
-            assertThatThrownBy(() -> marketCreateOrderUseCase.createOrder(memberId, request))
+            assertThatThrownBy(() -> marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey))
                     .isInstanceOf(CustomException.class)
                     .satisfies(ex -> {
                         CustomException customException = (CustomException) ex;
@@ -137,7 +139,7 @@ class MarketCreateOrderUseCaseTest {
 
             // when - 두 번째 주문 시도
             // then - 차단됨
-            assertThatThrownBy(() -> marketCreateOrderUseCase.createOrder(memberId, request))
+            assertThatThrownBy(() -> marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey))
                     .isInstanceOf(CustomException.class)
                     .satisfies(ex -> {
                         CustomException customException = (CustomException) ex;
@@ -148,10 +150,9 @@ class MarketCreateOrderUseCaseTest {
         }
 
         @Test
-        @DisplayName("같은 멱등 키 재요청이면 기존 주문을 반환한다")
-        void createOrder_sameIdempotencyKey_returnsExistingOrder() {
+        @DisplayName("멱등성 키가 없으면 ORDER_IDEMPOTENCY_KEY_REQUIRED 예외가 발생한다")
+        void createOrder_idempotencyKeyMissing_throwsException() {
             Long memberId = 1L;
-            String idempotencyKey = "order-create-1";
             OrderCreateRequest request = new OrderCreateRequest(
                     List.of(1L),
                     "12345",
@@ -159,27 +160,21 @@ class MarketCreateOrderUseCaseTest {
                     "101호"
             );
 
-            Order existingOrder = new Order(buyer, "12345", "서울시 강남구", "101호");
-            existingOrder.assignIdempotencyKey(idempotencyKey);
+            assertThatThrownBy(() -> marketCreateOrderUseCase.createOrder(memberId, request, null))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customException = (CustomException) ex;
+                        assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.ORDER_IDEMPOTENCY_KEY_REQUIRED);
+                    });
 
-            given(marketMemberRepository.findByIdForUpdate(memberId)).willReturn(Optional.of(buyer));
-            given(orderRepository.findByBuyerIdAndIdempotencyKey(memberId, idempotencyKey))
-                    .willReturn(Optional.of(existingOrder));
-            given(marketSupport.getWallet(memberId)).willReturn(new WalletInfo(1_000L));
-
-            OrderCreateResponse response = marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey);
-
-            assertThat(response.orderNumber()).isEqualTo(existingOrder.getOrderNumber());
-            assertThat(response.pgAmount()).isEqualTo(0L);
             verify(orderRepository, never()).existsByBuyerIdAndState(any(), any());
             verify(cartRepository, never()).findByBuyer(any());
         }
 
         @Test
-        @DisplayName("동시 요청으로 유니크 충돌이 나면 기존 주문을 반환한다")
-        void createOrder_uniqueConstraintConflict_returnsExistingOrder() {
+        @DisplayName("동시 요청으로 유니크 충돌이 나면 DataIntegrityViolationException이 facade로 전파된다")
+        void createOrder_uniqueConstraintConflict_throwsDataIntegrityViolationException() {
             Long memberId = 1L;
-            String idempotencyKey = "order-create-1";
             MarketPolicy.PRODUCT_PAYOUT_RATE = 90.0;
             OrderCreateRequest request = new OrderCreateRequest(
                     List.of(1L),
@@ -205,33 +200,16 @@ class MarketCreateOrderUseCaseTest {
                     "ON_SALE"
             );
 
-            Order existingOrder = new Order(buyer, "12345", "서울시 강남구", "101호");
-            existingOrder.assignIdempotencyKey(idempotencyKey);
-            existingOrder.addItem(
-                    2L,
-                    10L,
-                    "기계식 키보드",
-                    "keyboard.jpg",
-                    50_000L,
-                    40_000L,
-                    1
-            );
-
             given(marketMemberRepository.findByIdForUpdate(memberId)).willReturn(Optional.of(buyer));
-            given(orderRepository.findByBuyerIdAndIdempotencyKey(memberId, idempotencyKey))
-                    .willReturn(Optional.empty(), Optional.of(existingOrder));
             given(orderRepository.existsByBuyerIdAndState(memberId, OrderState.PENDING_PAYMENT))
                     .willReturn(false);
             given(cartRepository.findByBuyer(buyer)).willReturn(Optional.of(cart));
             given(marketSupport.getProducts(List.of(10L))).willReturn(List.of(productInfo));
             given(orderRepository.saveAndFlush(any(Order.class)))
                     .willThrow(new DataIntegrityViolationException("unique constraint violation"));
-            given(marketSupport.getWallet(memberId)).willReturn(new WalletInfo(5_000L));
 
-            OrderCreateResponse response = marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey);
-
-            assertThat(response.orderNumber()).isEqualTo(existingOrder.getOrderNumber());
-            assertThat(response.pgAmount()).isEqualTo(35_000L);
+            assertThatThrownBy(() -> marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey))
+                    .isInstanceOf(DataIntegrityViolationException.class);
         }
     }
 
@@ -244,6 +222,7 @@ class MarketCreateOrderUseCaseTest {
         void createOrder_memberNotFound_throwsException() {
             // given
             Long memberId = 999L;
+            String idempotencyKey = "order-create-1";
             OrderCreateRequest request = new OrderCreateRequest(
                     List.of(1L),
                     "12345",
@@ -254,7 +233,7 @@ class MarketCreateOrderUseCaseTest {
             given(marketMemberRepository.findByIdForUpdate(memberId)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> marketCreateOrderUseCase.createOrder(memberId, request))
+            assertThatThrownBy(() -> marketCreateOrderUseCase.createOrder(memberId, request, idempotencyKey))
                     .isInstanceOf(CustomException.class)
                     .satisfies(ex -> {
                         CustomException customException = (CustomException) ex;


### PR DESCRIPTION
## 🔗 관련 이슈
- #405 

## 📝 작업 내용
  - 주문 생성 API에 X-Idempotency-Key 필수 처리 추가
  - ORDER_IDEMPOTENCY_KEY_REQUIRED ErrorCode 추가
  - 주문 생성 시 save -> saveAndFlush 로 변경하여 DB 유니크 제약 위반을 flush 시점 에 즉시 감지하도록 수정
  - 기존에는 주문 생성 로직이 하나의 트랜잭션으로 묶여 있어, UseCase 내부에서 DataIntegrityViolationException 을 복구하려 할 때 트랜잭션이 이미 rollback-only 상태가 되어 커밋 시 UnexpectedRollbackException 이 발생했음
  - 이를 해결하기 위해 주문 생성 예외 복구 책임을 UseCase 에서 Facade 로 이동
  - MarketFacade#createOrder 는 비트랜잭션으로 두고, MarketCreateOrderUseCase#createOrder 만 트랜잭션을 수행하도록 변경
  - UseCase 는 DataIntegrityViolationException 발생 시 정상 응답으로 복구하지 않고 예외를 그대로 상위로 전파하며, 해당 트랜잭션은 rollback-only 상태로 종료됨
  - Facade 는 트랜잭션 바깥에서 DataIntegrityViolationException 을 catch 한 뒤 멱등성 키로 기존 주문을 재조회하여 정상 응답으로 복구
  - 결과적으로 주문 생성 흐름에서 UnexpectedRollbackException 은 더 이상 발생하지 않고, DB 무결성 위반 예외만 Facade 로 위임되어 처리됨
  - 관련 단위 테스트 및 통합 테스트를 현재 구조에 맞게 수정
  - 동시 요청 unique 충돌 상황에서 UnexpectedRollbackException 없이 기존 주문 응답 을 반환하는 시나리오 검증 추가

### 🧪 테스트 (검증/실행 방법/결과)
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [ ] 로컬에서 테스트 완료
- [ ] Postman/Swagger 테스트 완료

### 📸 스크린샷 (선택사항)
API 테스트 결과나 UI 변경사항 등

## 📋 리뷰 요청 사항 (선택사항)
리뷰어가 특히 봐주었으면 하는 부분을 적어주세요.
- 
-

## 📚 참고 자료 (선택사항)
관련 문서나 레퍼런스가 있다면 링크를 추가해주세요.
- 
-


