### PR TITLE
[FEAT] #409 market-service 모니터링 성능 지표 개선

### DIFF
--- a/market-service/build.gradle
+++ b/market-service/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security' // 인증 및 권한 부여를 위한 스프링 시큐리티
     implementation 'org.springframework.boot:spring-boot-starter-webflux' // webClient
+    implementation 'net.ttddyy:datasource-proxy:1.10.1'
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
@@ -47,6 +48,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // JWT

--- a/market-service/src/main/java/com/thock/back/market/app/MarketSupport.java
+++ b/market-service/src/main/java/com/thock/back/market/app/MarketSupport.java
@@ -10,6 +10,8 @@ import com.thock.back.market.out.client.PaymentWalletClient;
 import com.thock.back.market.out.client.ProductClient;
 import com.thock.back.market.out.repository.CartRepository;
 import com.thock.back.market.out.repository.MarketMemberRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +35,7 @@ public class MarketSupport {
      */
     private final ProductClient productClient; // 인터페이스로 주입 : ProductApiClient 라는 구체 클래스에 의존❌
     private final PaymentWalletClient paymentWalletClient;
+    private final MeterRegistry meterRegistry;
 
     public Optional<Cart> findCartByBuyer(MarketMember buyer) {
         return cartRepository.findByBuyer(buyer);
@@ -47,7 +51,9 @@ public class MarketSupport {
     // Product 정보 조회 - 단건
     @Transactional(readOnly = true)
     public ProductInfo getProduct(Long productId) {
-        List<ProductInfo> products = productClient.getProducts(List.of(productId));
+        List<ProductInfo> products = recordExternalApiCall("product-client", "getProduct", () ->
+                productClient.getProducts(List.of(productId))
+        );
 
         if (products == null || products.isEmpty()) {
             log.warn("Product 정보가 없음: productId={}", productId);
@@ -60,8 +66,9 @@ public class MarketSupport {
     // Cart에 들어있는 여러 CartItem 조회
     @Transactional(readOnly = true)
     public List<ProductInfo> getProducts(List<Long> productIds) {
-
-        List<ProductInfo> products = productClient.getProducts(productIds);
+        List<ProductInfo> products = recordExternalApiCall("product-client", "getProducts", () ->
+                productClient.getProducts(productIds)
+        );
 
         if (products == null) {
             log.warn("Product 정보 리스트가 null: productIds={}", productIds);
@@ -73,7 +80,9 @@ public class MarketSupport {
 
     @Transactional(readOnly = true)
     public WalletInfo getWallet(Long memberId) {
-        WalletInfo wallet = paymentWalletClient.getWallet(memberId);
+        WalletInfo wallet = recordExternalApiCall("payment-wallet-client", "getWallet", () ->
+                paymentWalletClient.getWallet(memberId)
+        );
 
         if (wallet == null) {
             log.warn("Wallet 정보가 null: memberId={}", memberId);
@@ -81,5 +90,33 @@ public class MarketSupport {
         }
 
         return wallet;
+    }
+
+    private <T> T recordExternalApiCall(String clientName, String operation, SupplierWithException<T> action) {
+        long startedAt = System.nanoTime();
+        String outcome = "success";
+
+        try {
+            return action.get();
+        } catch (RuntimeException e) {
+            outcome = "error";
+            throw e;
+        } finally {
+            Timer.builder("market_external_api_latency")
+                    .description("External API latency from market-service")
+                    .tags(
+                            "client", clientName,
+                            "operation", operation,
+                            "outcome", outcome
+                    )
+                    .publishPercentileHistogram()
+                    .register(meterRegistry)
+                    .record(System.nanoTime() - startedAt, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @FunctionalInterface
+    private interface SupplierWithException<T> {
+        T get();
     }
 }

--- a/market-service/src/main/java/com/thock/back/market/monitoring/sql/MarketDatasourceProxyConfiguration.java
+++ b/market-service/src/main/java/com/thock/back/market/monitoring/sql/MarketDatasourceProxyConfiguration.java
@@ -1,0 +1,50 @@
+package com.thock.back.market.monitoring.sql;
+
+import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+import net.ttddyy.dsproxy.ExecutionInfo;
+import net.ttddyy.dsproxy.QueryInfo;
+import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import javax.sql.DataSource;
+
+@Configuration
+public class MarketDatasourceProxyConfiguration {
+
+    @Bean
+    public BeanPostProcessor marketDataSourceProxyBeanPostProcessor() {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+                if (!(bean instanceof DataSource dataSource)) {
+                    return bean;
+                }
+
+                if (beanName != null && beanName.contains("proxy")) {
+                    return bean;
+                }
+
+                QueryExecutionListener listener = new QueryExecutionListener() {
+                    @Override
+                    public void beforeQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+                    }
+
+                    @Override
+                    public void afterQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+                        MarketRequestSqlMetricsContext.recordQueryTime(execInfo.getElapsedTime());
+                    }
+                };
+
+                return ProxyDataSourceBuilder
+                        .create(dataSource)
+                        .name("market-datasource-proxy")
+                        .listener(listener)
+                        .build();
+            }
+        };
+    }
+}

--- a/market-service/src/main/java/com/thock/back/market/monitoring/sql/MarketRequestSqlMetricsContext.java
+++ b/market-service/src/main/java/com/thock/back/market/monitoring/sql/MarketRequestSqlMetricsContext.java
@@ -1,0 +1,89 @@
+package com.thock.back.market.monitoring.sql;
+
+public final class MarketRequestSqlMetricsContext {
+
+    private static final ThreadLocal<MutableSnapshot> HOLDER = new ThreadLocal<>();
+
+    private MarketRequestSqlMetricsContext() {
+    }
+
+    public static void start(String method, String uri) {
+        HOLDER.set(new MutableSnapshot(method, uri));
+    }
+
+    public static void recordQuery(String sql) {
+        MutableSnapshot snapshot = HOLDER.get();
+        if (snapshot == null || sql == null) {
+            return;
+        }
+
+        snapshot.totalQueries++;
+
+        String normalized = sql.stripLeading().toLowerCase();
+        if (normalized.startsWith("select")) {
+            snapshot.selectQueries++;
+        } else if (normalized.startsWith("insert")) {
+            snapshot.insertQueries++;
+        } else if (normalized.startsWith("update")) {
+            snapshot.updateQueries++;
+        } else if (normalized.startsWith("delete")) {
+            snapshot.deleteQueries++;
+        }
+    }
+
+    public static void recordQueryTime(long elapsedMillis) {
+        MutableSnapshot snapshot = HOLDER.get();
+        if (snapshot == null || elapsedMillis < 0) {
+            return;
+        }
+        snapshot.totalQueryTimeMs += elapsedMillis;
+    }
+
+    public static Snapshot finish() {
+        MutableSnapshot snapshot = HOLDER.get();
+        HOLDER.remove();
+
+        if (snapshot == null) {
+            return null;
+        }
+
+        return new Snapshot(
+                snapshot.method,
+                snapshot.uri,
+                snapshot.totalQueries,
+                snapshot.selectQueries,
+                snapshot.insertQueries,
+                snapshot.updateQueries,
+                snapshot.deleteQueries,
+                snapshot.totalQueryTimeMs
+        );
+    }
+
+    private static final class MutableSnapshot {
+        private final String method;
+        private final String uri;
+        private int totalQueries;
+        private int selectQueries;
+        private int insertQueries;
+        private int updateQueries;
+        private int deleteQueries;
+        private long totalQueryTimeMs;
+
+        private MutableSnapshot(String method, String uri) {
+            this.method = method;
+            this.uri = uri;
+        }
+    }
+
+    public record Snapshot(
+            String method,
+            String uri,
+            int totalQueries,
+            int selectQueries,
+            int insertQueries,
+            int updateQueries,
+            int deleteQueries,
+            long totalQueryTimeMs
+    ) {
+    }
+}

--- a/market-service/src/main/java/com/thock/back/market/monitoring/sql/MarketRequestSqlMetricsFilter.java
+++ b/market-service/src/main/java/com/thock/back/market/monitoring/sql/MarketRequestSqlMetricsFilter.java
@@ -1,0 +1,58 @@
+package com.thock.back.market.monitoring.sql;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.io.IOException;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 20)
+@RequiredArgsConstructor
+public class MarketRequestSqlMetricsFilter extends OncePerRequestFilter {
+
+    private final MarketRequestSqlMetricsRecorder metricsRecorder;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        return uri == null || !uri.startsWith("/api/");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        MarketRequestSqlMetricsContext.start(request.getMethod(), request.getRequestURI());
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            Object bestMatchingPattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+            String uri = bestMatchingPattern != null ? bestMatchingPattern.toString() : request.getRequestURI();
+
+            MarketRequestSqlMetricsContext.Snapshot snapshot = MarketRequestSqlMetricsContext.finish();
+            if (snapshot != null) {
+                metricsRecorder.record(
+                        new MarketRequestSqlMetricsContext.Snapshot(
+                                snapshot.method(),
+                                uri,
+                                snapshot.totalQueries(),
+                                snapshot.selectQueries(),
+                                snapshot.insertQueries(),
+                                snapshot.updateQueries(),
+                                snapshot.deleteQueries(),
+                                snapshot.totalQueryTimeMs()
+                        ),
+                        response.getStatus()
+                );
+            }
+        }
+    }
+}

--- a/market-service/src/main/java/com/thock/back/market/monitoring/sql/MarketRequestSqlMetricsRecorder.java
+++ b/market-service/src/main/java/com/thock/back/market/monitoring/sql/MarketRequestSqlMetricsRecorder.java
@@ -1,0 +1,76 @@
+package com.thock.back.market.monitoring.sql;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class MarketRequestSqlMetricsRecorder {
+
+    private final MeterRegistry meterRegistry;
+
+    @Value("${market.metrics.n-plus-one-select-threshold:15}")
+    private int nPlusOneSelectThreshold;
+
+    public void record(MarketRequestSqlMetricsContext.Snapshot snapshot, int status) {
+        if (snapshot == null) {
+            return;
+        }
+
+        Tags tags = Tags.of(
+                "method", snapshot.method(),
+                "uri", snapshot.uri(),
+                "status", String.valueOf(status)
+        );
+
+        DistributionSummary.builder("market_http_db_queries")
+                .description("Total SQL statements executed per HTTP request")
+                .baseUnit("queries")
+                .serviceLevelObjectives(1, 3, 5, 10, 20, 50, 100, 200)
+                .tags(tags)
+                .register(meterRegistry)
+                .record(snapshot.totalQueries());
+
+        DistributionSummary.builder("market_http_db_select_queries")
+                .description("Total SELECT statements executed per HTTP request")
+                .baseUnit("queries")
+                .serviceLevelObjectives(1, 3, 5, 10, 20, 50, 100, 200)
+                .tags(tags)
+                .register(meterRegistry)
+                .record(snapshot.selectQueries());
+
+        Timer.builder("market_http_db_time")
+                .description("Total DB execution time per HTTP request")
+                .tags(tags)
+                .publishPercentileHistogram()
+                .serviceLevelObjectives(
+                        Duration.ofMillis(5),
+                        Duration.ofMillis(10),
+                        Duration.ofMillis(25),
+                        Duration.ofMillis(50),
+                        Duration.ofMillis(100),
+                        Duration.ofMillis(250),
+                        Duration.ofMillis(500),
+                        Duration.ofSeconds(1)
+                )
+                .register(meterRegistry)
+                .record(snapshot.totalQueryTimeMs(), TimeUnit.MILLISECONDS);
+
+        if (snapshot.selectQueries() >= nPlusOneSelectThreshold) {
+            Counter.builder("market_http_db_n_plus_one_suspected_total")
+                    .description("Requests suspected of N+1 due to high SELECT count")
+                    .tags(tags)
+                    .register(meterRegistry)
+                    .increment();
+        }
+    }
+}

--- a/market-service/src/main/java/com/thock/back/market/monitoring/sql/MarketSqlMetricsConfiguration.java
+++ b/market-service/src/main/java/com/thock/back/market/monitoring/sql/MarketSqlMetricsConfiguration.java
@@ -1,0 +1,26 @@
+package com.thock.back.market.monitoring.sql;
+
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+@Configuration
+public class MarketSqlMetricsConfiguration {
+
+    @Bean
+    public MarketSqlStatementInspector marketSqlStatementInspector() {
+        return new MarketSqlStatementInspector();
+    }
+
+    @Bean
+    public HibernatePropertiesCustomizer hibernateStatementInspectorCustomizer(
+            MarketSqlStatementInspector marketSqlStatementInspector
+    ) {
+        return hibernateProperties -> hibernateProperties.put(
+                "hibernate.session_factory.statement_inspector",
+                marketSqlStatementInspector
+        );
+    }
+}

--- a/market-service/src/main/java/com/thock/back/market/monitoring/sql/MarketSqlStatementInspector.java
+++ b/market-service/src/main/java/com/thock/back/market/monitoring/sql/MarketSqlStatementInspector.java
@@ -1,0 +1,12 @@
+package com.thock.back.market.monitoring.sql;
+
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+
+public class MarketSqlStatementInspector implements StatementInspector {
+
+    @Override
+    public String inspect(String sql) {
+        MarketRequestSqlMetricsContext.recordQuery(sql);
+        return sql;
+    }
+}

--- a/market-service/src/main/resources/application-local.yml
+++ b/market-service/src/main/resources/application-local.yml
@@ -6,7 +6,6 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3307/thock_market_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
-    password: root
 
   flyway:
     enabled: true

--- a/market-service/src/main/resources/application.yml
+++ b/market-service/src/main/resources/application.yml
@@ -67,6 +67,7 @@ market:
     enabled: true
     collect-interval-ms: 10000
     consumer-group-id: market-service
+    n-plus-one-select-threshold: 15
 
 # JWT 설정
 jwt:

--- a/member-service/src/main/resources/application-docker.yml
+++ b/member-service/src/main/resources/application-docker.yml
@@ -14,11 +14,20 @@ spring:
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
 
+#  flyway:
+#    enabled: true
+#    locations: classpath:db/migration
+#    validate-on-migrate: true
+#    clean-disabled: true
+#    baseline-on-migrate: true
+
   flyway:
     enabled: true
     locations: classpath:db/migration
     validate-on-migrate: true
-    clean-disabled: true
+    clean-disabled: false       # 개발 중엔 DB를 밀어야 할 수도 있으니 허용
+    baseline-on-migrate: true   # 팀원들 로컬 DB에 장부 자동 생성
+    baseline-version: 0
 
   jpa:
     hibernate:

--- a/monitoring/grafana/dashboards/market-service-dashboard.json
+++ b/monitoring/grafana/dashboards/market-service-dashboard.json
@@ -1,5 +1,7 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "graphTooltip": 0,
   "id": null,
@@ -8,103 +10,1142 @@
   "panels": [
     {
       "datasource": "Prometheus",
-      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 0 },
-      "id": 1,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 300
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 26,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value"
       },
-      "targets": [{ "expr": "market_order_total_count{job=\"market-service\"}", "refId": "A" }],
+      "targets": [
+        {
+          "expr": "process_uptime_seconds{job=\"market-service\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 27,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes{job=\"market-service\",area=\"heap\"}) / clamp_min(sum(jvm_memory_max_bytes{job=\"market-service\",area=\"heap\"}), 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "Heap Used",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 28,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes{job=\"market-service\",area=\"nonheap\"}) / clamp_min(sum(jvm_memory_committed_bytes{job=\"market-service\",area=\"nonheap\"}), 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "Non-Heap Used",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "process_files_open_files{job=\"market-service\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Process Open Files",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "pointSize": 3,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "min"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "system_cpu_usage{job=\"market-service\"}",
+          "legendFormat": "System CPU Usage",
+          "refId": "A"
+        },
+        {
+          "expr": "process_cpu_usage{job=\"market-service\"}",
+          "legendFormat": "Process CPU Usage",
+          "refId": "B"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "pointSize": 3,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "min"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "system_load_average_1m{job=\"market-service\"}",
+          "legendFormat": "Load Average [1m]",
+          "refId": "A"
+        },
+        {
+          "expr": "system_cpu_count{job=\"market-service\"}",
+          "legendFormat": "CPU Core Size",
+          "refId": "B"
+        }
+      ],
+      "title": "Load Average",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 14
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=\"market-service\",uri=~\"/api/.*\"}[1m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "API TPS",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 3,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.3
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 14
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{job=\"market-service\",uri=~\"/api/.*\"}[1m])) by (le))",
+          "refId": "A"
+        }
+      ],
+      "title": "API P95 Latency",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 3,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1.5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 14
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket{job=\"market-service\",uri=~\"/api/.*\"}[1m])) by (le))",
+          "refId": "A"
+        }
+      ],
+      "title": "API P99 Latency",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(market_http_db_queries_sum{job=\"market-service\",uri=~\"/api/.*\"}[1m])) / clamp_min(sum(rate(market_http_db_queries_count{job=\"market-service\",uri=~\"/api/.*\"}[1m])), 0.001)",
+          "refId": "A"
+        }
+      ],
+      "title": "Avg SQL / Request",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 19
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(market_http_db_n_plus_one_suspected_total{job=\"market-service\",uri=~\"/api/.*\"}[$__range]))",
+          "refId": "A"
+        }
+      ],
+      "title": "N+1 의심 요청 수",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 19
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=\"market-service\",uri=~\"/api/.*\",status=~\"5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{job=\"market-service\",uri=~\"/api/.*\"}[1m])), 0.001)",
+          "refId": "A"
+        }
+      ],
+      "title": "API 5xx Error Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 19
+      },
+      "id": 33,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "(sum(rate(market_http_db_time_seconds_sum{job=\"market-service\",uri=~\"/api/.*\"}[1m])) / clamp_min(sum(rate(market_http_db_time_seconds_count{job=\"market-service\",uri=~\"/api/.*\"}[1m])), 0.001)) * 1000",
+          "refId": "A"
+        }
+      ],
+      "title": "Avg DB Time / Request",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 35,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(market_external_api_latency_seconds_bucket{job=\"market-service\"}[1m])) by (le, client, operation)) * 1000",
+          "legendFormat": "{{client}} {{operation}} p95",
+          "refId": "A"
+        }
+      ],
+      "title": "External API Latency P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 16,
+            "showPoints": "never",
+            "pointSize": 3,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=\"market-service\",uri=~\"/api/.*\"}[1m]))",
+          "legendFormat": "TPS",
+          "refId": "A"
+        }
+      ],
+      "title": "API TPS Trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 16,
+            "showPoints": "never",
+            "pointSize": 3,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{job=\"market-service\",uri=~\"/api/.*\"}[1m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket{job=\"market-service\",uri=~\"/api/.*\"}[1m])) by (le))",
+          "legendFormat": "P99",
+          "refId": "B"
+        }
+      ],
+      "title": "API Latency Trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "pointSize": 3,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum(rate(market_http_db_queries_sum{job=\"market-service\",uri=~\"/api/.*\"}[1m])) by (uri) / clamp_min(sum(rate(market_http_db_queries_count{job=\"market-service\",uri=~\"/api/.*\"}[1m])) by (uri), 0.001))",
+          "legendFormat": "{{uri}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top API SQL / Request",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "pointSize": 3,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum(rate(market_http_db_select_queries_sum{job=\"market-service\",uri=~\"/api/.*\"}[1m])) by (uri) / clamp_min(sum(rate(market_http_db_select_queries_count{job=\"market-service\",uri=~\"/api/.*\"}[1m])) by (uri), 0.001))",
+          "legendFormat": "{{uri}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top API SELECT / Request",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 34,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "topk(10, (sum(rate(market_http_db_time_seconds_sum{job=\"market-service\",uri=~\"/api/.*\"}[1m])) by (uri) / clamp_min(sum(rate(market_http_db_time_seconds_count{job=\"market-service\",uri=~\"/api/.*\"}[1m])) by (uri), 0.001)) * 1000)",
+          "legendFormat": "{{uri}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top API DB Time / Request",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 36,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=\"market-service\",uri=~\"/api/.*\",status=~\"4..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{job=\"market-service\",uri=~\"/api/.*\"}[1m])), 0.001)",
+          "legendFormat": "4xx rate",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=\"market-service\",uri=~\"/api/.*\",status=~\"5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{job=\"market-service\",uri=~\"/api/.*\"}[1m])), 0.001)",
+          "legendFormat": "5xx rate",
+          "refId": "B"
+        }
+      ],
+      "title": "API Error Rate Trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 51
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "market_order_total_count{job=\"market-service\"}",
+          "refId": "A"
+        }
+      ],
       "title": "주문 총 건수",
       "type": "stat"
     },
     {
       "datasource": "Prometheus",
-      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 0 },
-      "id": 2,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "value"
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
       },
-      "targets": [{ "expr": "market_outbox_total_count{job=\"market-service\"}", "refId": "A" }],
-      "title": "Outbox 총 건수",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": { "defaults": { "unit": "percent", "decimals": 0 }, "overrides": [] },
-      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 0 },
-      "id": 3,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "value"
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 51
       },
-      "targets": [{ "expr": "market_outbox_failed_ratio_percent{job=\"market-service\"}", "refId": "A" }],
-      "title": "FAILED 비율",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": { "defaults": { "unit": "percent", "decimals": 0 }, "overrides": [] },
-      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 0 },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "value"
-      },
-      "targets": [{ "expr": "market_outbox_backlog_ratio_percent{job=\"market-service\"}", "refId": "A" }],
-      "title": "미처리 비율",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 5, "w": 4, "x": 16, "y": 0 },
-      "id": 5,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "value"
-      },
-      "targets": [{ "expr": "max((market_kafka_consumer_lag_total{job=\"market-service\"}) or (market_kafka_consumer_lag{job=\"market-service\"}))", "refId": "A" }],
-      "title": "Kafka Lag Total",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 5, "w": 4, "x": 20, "y": 0 },
       "id": 6,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value"
       },
-      "targets": [{ "expr": "market_outbox_status_count{job=\"market-service\",status=\"FAILED\"}", "refId": "A" }],
+      "targets": [
+        {
+          "expr": "market_outbox_status_count{job=\"market-service\",status=\"FAILED\"}",
+          "refId": "A"
+        }
+      ],
       "title": "FAILED 건수",
       "type": "stat"
     },
@@ -114,17 +1155,242 @@
         "defaults": {
           "unit": "short",
           "min": 0,
-          "color": { "mode": "continuous-BlYlRd" }
+          "color": {
+            "mode": "continuous-BlYlRd"
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 5 },
-      "id": 7,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 51
+      },
+      "id": 5,
       "options": {
         "displayMode": "gradient",
         "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "max((market_kafka_consumer_lag_total{job=\"market-service\"}) or (market_kafka_consumer_lag{job=\"market-service\"}))",
+          "refId": "A"
+        }
+      ],
+      "title": "Kafka Lag Total",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": {
+            "mode": "continuous-BlYlRd"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 51
+      },
+      "id": 2,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "market_outbox_total_count{job=\"market-service\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Outbox 총 건수",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 56
+      },
+      "id": 3,
+      "options": {
+        "displayLabels": [
+          "name",
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "values": [
+            "percent"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "market_outbox_failed_ratio_percent{job=\"market-service\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "FAILED 비율",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "showPoints": "never",
+            "pointSize": 3,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 56
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "market_outbox_backlog_ratio_percent{job=\"market-service\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "미처리 비율",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 56
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(market_kafka_inbound_received_total{job=\"market-service\"}[$__range]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Inbound 수신 건수(기간)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 61
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
       },
       "targets": [
         {
@@ -140,19 +1406,30 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
-          "min": 0,
-          "color": { "mode": "continuous-BlYlRd" }
+          "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 5 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 66
+      },
       "id": 8,
       "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "showUnfilled": true
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
       },
       "targets": [
         {
@@ -166,15 +1443,42 @@
     },
     {
       "datasource": "Prometheus",
-      "fieldConfig": { "defaults": { "unit": "percent", "decimals": 1 }, "overrides": [] },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "pointSize": 3,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 69
+      },
       "id": 9,
       "options": {
-        "displayLabels": ["name", "percent"],
-        "legend": { "displayMode": "list", "placement": "bottom", "values": ["percent"] },
-        "pieType": "pie",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "tooltip": { "mode": "single" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -196,7 +1500,7 @@
             "drawStyle": "line",
             "lineInterpolation": "smooth",
             "lineWidth": 2,
-            "fillOpacity": 18,
+            "fillOpacity": 12,
             "showPoints": "never",
             "pointSize": 3,
             "spanNulls": true
@@ -204,15 +1508,25 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 74
+      },
       "id": 10,
       "options": {
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": ["lastNotNull", "max"]
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -226,37 +1540,52 @@
     },
     {
       "datasource": "Prometheus",
-      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 22 },
-      "id": 11,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "value"
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 3,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          }
+        },
+        "overrides": []
       },
-      "targets": [
-        {
-          "expr": "sum(increase(market_kafka_inbound_received_total{job=\"market-service\"}[$__range]))",
-          "refId": "A"
-        }
-      ],
-      "title": "Inbound 수신 건수(기간)",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 22 },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 56
+      },
       "id": 12,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value"
       },
       "targets": [
@@ -270,15 +1599,52 @@
     },
     {
       "datasource": "Prometheus",
-      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 22 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 61
+      },
       "id": 13,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value"
       },
       "targets": [
@@ -292,16 +1658,42 @@
     },
     {
       "datasource": "Prometheus",
-      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 22 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "pointSize": 3,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 61
+      },
       "id": 14,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "value"
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -316,7 +1708,7 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "ms",
           "min": 0,
           "custom": {
             "drawStyle": "line",
@@ -330,15 +1722,26 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 27 },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
       "id": 15,
       "options": {
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": ["lastNotNull", "mean", "max"]
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -362,21 +1765,94 @@
           "refId": "D"
         }
       ],
-      "title": "Inbound 이벤트 처리 추이 (topic별)",
+      "title": "Inbound 이벤트 처리 추이",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "pointSize": 3,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 91
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "hikaricp_connections_active{job=\"market-service\"}",
+          "legendFormat": "active",
+          "refId": "A"
+        },
+        {
+          "expr": "hikaricp_connections_pending{job=\"market-service\"}",
+          "legendFormat": "pending",
+          "refId": "B"
+        },
+        {
+          "expr": "hikaricp_connections_idle{job=\"market-service\"}",
+          "legendFormat": "idle",
+          "refId": "C"
+        }
+      ],
+      "title": "HikariCP 연결 상태",
       "type": "timeseries"
     }
   ],
   "refresh": "10s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["market", "prometheus", "kafka", "outbox", "inbound", "inbox"],
+  "tags": [
+    "market",
+    "prometheus",
+    "kafka",
+    "outbox",
+    "inbound",
+    "inbox",
+    "http",
+    "db",
+    "n-plus-one"
+  ],
   "templating": {
     "list": [
       {
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "Prometheus",
         "definition": "label_values(market_kafka_consumer_lag_topic{job=\"market-service\"}, topic)",
@@ -395,11 +1871,14 @@
       }
     ]
   },
-  "time": { "from": "now-24h", "to": "now" },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "Asia/Seoul",
   "title": "Market Service Dashboard",
   "uid": "market-service-dashboard",
-  "version": 3,
+  "version": 8,
   "weekStart": ""
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #409

## 📝 작업 내용
### JVM/Process
- Uptime
- Heap Used
- Non-Heap Used
- Process Open Files
- CPU Usage
- Load Average
### API Performance
- API TPS
- P95/99 Latency
- Avg SQL / Request
- API 5xx Error Rate
- External API Latency P95
- N+1 의심 요청 수
- Avg DB Time / Request

등 추가함 성능 개선 지표로 사용할 예정


### 🧪 테스트 (검증/실행 방법/결과)
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료
- [ ] 로컬에서 테스트 완료
- [ ] Postman/Swagger 테스트 완료

### 📸 스크린샷 (선택사항)

<img width="1431" height="718" alt="스크린샷 2026-04-13 오후 12 55 07" src="https://github.com/user-attachments/assets/978f3da7-0e02-4233-ac7b-13d5b3c75e24" />



## 📋 리뷰 요청 사항 (선택사항)
리뷰어가 특히 봐주었으면 하는 부분을 적어주세요.
- 
-

## 📚 참고 자료 (선택사항)
관련 문서나 레퍼런스가 있다면 링크를 추가해주세요.
- 
-


